### PR TITLE
add source code info to gemspec

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Python class generation.
  - Perl class generation.
 
+## [0.2.0] - 2019-05-03
+### Added
+ - Additional project information to gemspec.
+
 ## [0.1.0] - 2019-05-02
 ### Added
  - C++ class generation with member functions and constants.

--- a/lib/wrapture/version.rb
+++ b/lib/wrapture/version.rb
@@ -1,5 +1,5 @@
 module Wrapture
 
-  VERSION = '0.1.0'
+  VERSION = '0.2.0'
 
 end

--- a/wrapture.gemspec
+++ b/wrapture.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
     spec.metadata = {
       "bug_tracker_uri" => "https://github.com/goatshriek/wrapture/issues",
       "changelog_uri" => "https://github.com/goatshriek/wrapture/blob/master/ChangeLog.md",
-      "source_code_uri" => "https://github.com/goatshriek/wrapture/",
+      "source_code_uri" => "https://github.com/goatshriek/wrapture/"
     }
   end
 end

--- a/wrapture.gemspec
+++ b/wrapture.gemspec
@@ -12,4 +12,12 @@ Gem::Specification.new do |spec|
   spec.executables << 'wrapture'
   spec.homepage    =  'http://rubygems.org/gems/wrapture'
   spec.license     =  'Apache-2.0'
+
+  if spec.respond_to?(:metadata)
+    spec.metadata = {
+      "bug_tracker_uri" => "https://github.com/goatshriek/wrapture/issues",
+      "changelog_uri" => "https://github.com/goatshriek/wrapture/blob/master/ChangeLog.md",
+      "source_code_uri" => "https://github.com/goatshriek/wrapture/",
+    }
+  end
 end


### PR DESCRIPTION
Adds a metadata portion to the gemspec, including links for source code, bug tracking, and the changelog.