### PR TITLE
exclude tests in coverage reports

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,5 @@
 sonar.projectKey=wrapture
 sonar.sources=.
 sonar.exclusions=vendor/**
+sonar.coverage.exclusions=test/**
 sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
Sonarcloud has been including the tests directory in coverage reports. This excludes those directories, as coverage of these is not important enough to track.