### PR TITLE
remove docs from ci gem update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ matrix:
       gemfile: gemfiles/minimal.gemfile
 
 before_install:
-  - gem update --system
+  - gem update --system --no-document
   - if [[ $TRAVIS_RUBY_VERSION =~ "truffle" ]]; then gem install bundler -v 1.17.3 --no-document; else gem install bundler --no-document; fi
 
 script:

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Python class generation.
  - Perl class generation.
 
+## [0.2.1] - 2019-06-16
+### Fixed
+ - Add `--no-document` to CI scripts due to missing Darkfish support on
+   TruffleRuby.
+
 ## [0.2.0] - 2019-05-27
 ### Added
  - Additional project information to gemspec.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    wrapture (0.2.0)
+    wrapture (0.2.1)
       bundler (>= 1.6.4)
 
 GEM
@@ -12,7 +12,7 @@ GEM
       json
       simplecov
       url
-    docile (1.3.1)
+    docile (1.3.2)
     jaro_winkler (1.5.2)
     json (2.2.0)
     minitest (5.11.3)
@@ -21,14 +21,14 @@ GEM
       ast (~> 2.4.0)
     rainbow (3.0.0)
     rake (12.3.2)
-    rubocop (0.70.0)
+    rubocop (0.71.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.6)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
-    ruby-progressbar (1.10.0)
+    ruby-progressbar (1.10.1)
     simplecov (0.16.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)

--- a/lib/wrapture/version.rb
+++ b/lib/wrapture/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Wrapture
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end


### PR DESCRIPTION
Travis builds have started throwing errors on TruffleRuby builds, due to the lack of Darkfish support on that engine. This change adds the no-document flag to the gem update command in the travis before-install script so that this issue does not stop the CI builds.