### PR TITLE
add class-level include option

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.3.0] - 2019-07-07
 ### Added
  - Examples of basic usage and features.
+ - Option to give a class-level include list.
 
 ### Fixed
  - `bin/wrapture` is now executable.

--- a/docs/examples/basic/README.md
+++ b/docs/examples/basic/README.md
@@ -45,7 +45,7 @@ For most elements within Wrapture, you may also specify an `includes` list of
 header files necessary for the element, in this case the struct. Doing this for
 each element will result in more efficient header lists and compilation times in
 some cases, but this can be tedious. Specifying this at the class level, as we
-do here, is easier and less verbose.
+do above, is easier and less verbose.
 
 Next, we describe our only constructor function. We'll do this by specifying
 its name, parameters, and return type:

--- a/docs/examples/basic/README.md
+++ b/docs/examples/basic/README.md
@@ -23,33 +23,37 @@ int is_model_supported( int model );
 ```
 
 We would like to create a Stove class that mimics the functionality of this C
-code in our output language (C++). First, we add the class to the classes list:
+code in our output language (C++). First, we add the class to the classes list
+with a few basic attributes:
 
 ```yaml
 classes:
   - name: "Stove"
     namespace: "kitchen"
+    includes:
+      - "stove.h"
 ```
 
-We describe the underlying struct by giving its name and the include that it is
-declared in:
+We describe the underlying struct by simply giving its name:
 
 ```yaml
     equivalent-struct:
       name: "stove"
-      includes:
-        - "stove.h"
 ```
 
+For most elements within Wrapture, you may also specify an `includes` list of
+header files necessary for the element, in this case the struct. Doing this for
+each element will result in more efficient header lists and compilation times in
+some cases, but this can be tedious. Specifying this at the class level, as we
+do here, is easier and less verbose.
+
 Next, we describe our only constructor function. We'll do this by specifying
-its name, parameters, the include file it is declared in, and its return type:
+its name, parameters, and return type:
 
 ```yaml
     constructors:
       - wrapped-function:
           name: "new_stove"
-          includes:
-            - "stove.h"
           params:
             - name: "burner_count"
               type: "int"
@@ -67,8 +71,6 @@ Next, we describe the destructor function in a similar way:
     destructor:
       wrapped-function:
         name: "destroy_stove"
-        includes:
-          - "stove.h"
         params:
           - name: "equivalent-struct-pointer"
 ```
@@ -86,8 +88,6 @@ for working with the stove. Let's start with the two simplest:
           type: "int"
         wrapped-function:
           name: "get_burner_count"
-          includes:
-            - "stove.h"
           params:
             - name: "equivalent-struct-pointer"
       - name: "GetOvenTemp"
@@ -95,8 +95,6 @@ for working with the stove. Let's start with the two simplest:
           type: "int"
         wrapped-function:
           name: "get_oven_temp"
-          includes:
-            - "stove.h"
           params:
             - name: "equivalent-struct-pointer"
 ```
@@ -115,8 +113,6 @@ needed:
             type: "int"
         wrapped-function:
           name: "set_oven_temp"
-          includes:
-            - "stove.h"
           params:
             - name: "equivalent-struct-pointer"
             - name: "new_temp"
@@ -138,8 +134,6 @@ We can define the remaining two functions in the same way:
           type: "int"
         wrapped-function:
           name: "get_burner_level"
-          includes:
-            - "stove.h"
           params:
             - name: "equivalent-struct-pointer"
             - name: "burner_index"
@@ -151,8 +145,6 @@ We can define the remaining two functions in the same way:
             type: "int"
         wrapped-function:
           name: "set_burner_level"
-          includes:
-            - "stove.h"
           params:
             - name: "equivalent-struct-pointer"
             - name: "burner_index"
@@ -172,8 +164,6 @@ named `static` set to true.
             type: "int"
         wrapped-function:
           name: "is_model_supported"
-          includes:
-            - "stove.h"
           params:
             - name: "model"
 ```

--- a/docs/examples/basic/stove.yml
+++ b/docs/examples/basic/stove.yml
@@ -1,15 +1,13 @@
 classes:
   - name: "Stove"
     namespace: "kitchen"
+    includes:
+      - "stove.h"
     equivalent-struct:
       name: "stove"
-      includes:
-        - "stove.h"
     constructors:
       - wrapped-function:
           name: "new_stove"
-          includes:
-            - "stove.h"
           params:
             - name: "burner_count"
               type: "int"
@@ -18,8 +16,6 @@ classes:
     destructor:
       wrapped-function:
         name: "destroy_stove"
-        includes:
-          - "stove.h"
         params:
           - name: "equivalent-struct-pointer"
     functions:
@@ -28,8 +24,6 @@ classes:
           type: "int"
         wrapped-function:
           name: "get_burner_count"
-          includes:
-            - "stove.h"
           params:
             - name: "equivalent-struct-pointer"
       - name: "GetOvenTemp"
@@ -37,8 +31,6 @@ classes:
           type: "int"
         wrapped-function:
           name: "get_oven_temp"
-          includes:
-            - "stove.h"
           params:
             - name: "equivalent-struct-pointer"
       - name: "SetOvenTemp"
@@ -47,8 +39,6 @@ classes:
             type: "int"
         wrapped-function:
           name: "set_oven_temp"
-          includes:
-            - "stove.h"
           params:
             - name: "equivalent-struct-pointer"
             - name: "new_temp"
@@ -60,8 +50,6 @@ classes:
           type: "int"
         wrapped-function:
           name: "get_burner_level"
-          includes:
-            - "stove.h"
           params:
             - name: "equivalent-struct-pointer"
             - name: "burner_index"
@@ -73,8 +61,6 @@ classes:
             type: "int"
         wrapped-function:
           name: "set_burner_level"
-          includes:
-            - "stove.h"
           params:
             - name: "equivalent-struct-pointer"
             - name: "burner_index"
@@ -88,7 +74,5 @@ classes:
             type: "int"
         wrapped-function:
           name: "is_model_supported"
-          includes:
-            - "stove.h"
           params:
             - name: "model"

--- a/lib/wrapture/class_spec.rb
+++ b/lib/wrapture/class_spec.rb
@@ -15,6 +15,9 @@ module Wrapture
       normalized_spec = spec.dup
       normalized_spec.default = []
 
+      normalized_spec['includes'] ||= []
+      normalized_spec['includes'].uniq!
+
       normalized_spec['equivalent-struct']['members'] ||= []
       normalized_spec['equivalent-struct']['includes'] ||= []
       normalized_spec['equivalent-struct']['includes'].uniq!
@@ -99,6 +102,8 @@ module Wrapture
     def declaration_includes
       includes = @spec['equivalent-struct']['includes'].dup
 
+      includes.concat @spec['includes']
+
       @functions.each do |func|
         includes.concat func.declaration_includes
       end
@@ -113,6 +118,8 @@ module Wrapture
     # A list of includes needed for the definition of the class.
     def definition_includes
       includes = ["#{@spec['name']}.hpp"]
+
+      includes.concat @spec['includes']
 
       @functions.each do |func|
         includes.concat func.definition_includes

--- a/test/fixtures/basic_class.yml
+++ b/test/fixtures/basic_class.yml
@@ -1,4 +1,6 @@
 name: "BasicClass"
+includes:
+  - "class_include.h"
 equivalent-struct:
   name: "basic_struct"
   includes:

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -27,7 +27,7 @@ def validate_wrapper_results(spec, file_list)
 
   header_includes = []
   File.open("#{spec['name']}.hpp").each do |line|
-    if(m=line.match(/#\s*include\s*["<](.*)[">]/))
+    if (m = line.match(/#\s*include\s*["<](.*)[">]/))
       header_includes << m[1]
     end
   end
@@ -38,7 +38,7 @@ def validate_wrapper_results(spec, file_list)
 
   source_includes = []
   File.open("#{spec['name']}.hpp").each do |line|
-    if(m=line.match(/#\s*include\s*["<](.*)[">]/))
+    if (m = line.match(/#\s*include\s*["<](.*)[">]/))
       source_includes << m[1]
     end
   end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -16,6 +16,37 @@ end
 
 require 'minitest/autorun'
 
+def get_include_list(filename)
+  includes = []
+  File.open(filename).each do |line|
+    if (m = line.match(/#\s*include\s*["<](.*)[">]/))
+      includes << m[1]
+    end
+  end
+
+  includes
+end
+
+def validate_declaration_file(spec)
+  class_includes = spec['includes'] || []
+
+  includes = get_include_list "#{spec['name']}.hpp"
+
+  class_includes.each do |class_include|
+    assert_includes(includes, class_include)
+  end
+end
+
+def validate_definition_file(spec)
+  class_includes = spec['includes'] || []
+
+  includes = get_include_list "#{spec['name']}.cpp"
+
+  class_includes.each do |class_include|
+    assert_includes(includes, class_include)
+  end
+end
+
 def validate_wrapper_results(spec, file_list)
   refute_nil file_list
   refute_empty file_list
@@ -23,27 +54,6 @@ def validate_wrapper_results(spec, file_list)
   assert file_list.include? "#{spec['name']}.cpp"
   assert file_list.include? "#{spec['name']}.hpp"
 
-  class_includes = spec['includes'] || []
-
-  header_includes = []
-  File.open("#{spec['name']}.hpp").each do |line|
-    if (m = line.match(/#\s*include\s*["<](.*)[">]/))
-      header_includes << m[1]
-    end
-  end
-
-  class_includes.each do |class_include|
-    assert_includes(header_includes, class_include)
-  end
-
-  source_includes = []
-  File.open("#{spec['name']}.hpp").each do |line|
-    if (m = line.match(/#\s*include\s*["<](.*)[">]/))
-      source_includes << m[1]
-    end
-  end
-
-  class_includes.each do |class_include|
-    assert_includes(source_includes, class_include)
-  end
+  validate_declaration_file(spec)
+  validate_definition_file(spec)
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -22,4 +22,28 @@ def validate_wrapper_results(spec, file_list)
   assert file_list.length == 2
   assert file_list.include? "#{spec['name']}.cpp"
   assert file_list.include? "#{spec['name']}.hpp"
+
+  class_includes = spec['includes'] || []
+
+  header_includes = []
+  File.open("#{spec['name']}.hpp").each do |line|
+    if(m=line.match(/#\s*include\s*["<](.*)[">]/))
+      header_includes << m[1]
+    end
+  end
+
+  class_includes.each do |class_include|
+    assert_includes(header_includes, class_include)
+  end
+
+  source_includes = []
+  File.open("#{spec['name']}.hpp").each do |line|
+    if(m=line.match(/#\s*include\s*["<](.*)[">]/))
+      source_includes << m[1]
+    end
+  end
+
+  class_includes.each do |class_include|
+    assert_includes(source_includes, class_include)
+  end
 end


### PR DESCRIPTION
While specifying include lists on a per-element basis results in a more
efficient inclusion list in some cases, it can be tedious if everything in
the wrapped library is in a single include. This adds the option to provide
a class-level include list that removes the need for an include definition
for every element.