### PR TITLE
fix constant indentation

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
  - `bin/wrapture` is now executable.
+ - Class constants are indented properly.
 
 ## [0.2.2] - 2019-07-06
 ### Fixed

--- a/lib/wrapture/class_spec.rb
+++ b/lib/wrapture/class_spec.rb
@@ -262,7 +262,7 @@ module Wrapture
 
       yield unless @constants.empty?
       @constants.each do |const|
-        yield "  #{const.declaration};"
+        yield "    #{const.declaration};"
       end
 
       yield

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -41,13 +41,16 @@ def validate_declaration_file(spec)
 end
 
 def validate_definition_file(spec)
+  filename = "#{spec['name']}.cpp"
   class_includes = spec['includes'] || []
 
-  includes = get_include_list "#{spec['name']}.cpp"
+  includes = get_include_list filename
 
   class_includes.each do |class_include|
     assert_includes(includes, class_include)
   end
+
+  validate_indentation filename
 end
 
 def validate_indentation(filename)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -28,13 +28,16 @@ def get_include_list(filename)
 end
 
 def validate_declaration_file(spec)
+  filename = "#{spec['name']}.hpp"
   class_includes = spec['includes'] || []
 
-  includes = get_include_list "#{spec['name']}.hpp"
+  includes = get_include_list filename
 
   class_includes.each do |class_include|
     assert_includes(includes, class_include)
   end
+
+  validate_indentation filename
 end
 
 def validate_definition_file(spec)
@@ -44,6 +47,33 @@ def validate_definition_file(spec)
 
   class_includes.each do |class_include|
     assert_includes(includes, class_include)
+  end
+end
+
+def validate_indentation(filename)
+  line_number = 0
+  indent_level = 0
+
+  File.open(filename).each do |line|
+    line_number += 1
+
+    next if line.strip.empty?
+
+    line.chomp!
+
+    indent_level -= 1 if line.end_with? '}', '};'
+
+    space_count = if line.end_with? ':'
+                    (indent_level - 1) * 2
+                  else
+                    indent_level * 2
+                  end
+
+    fail_msg = "#{filename}: line #{line_number} should have #{space_count}" \
+               ' spaces'
+    assert line.start_with?(' ' * space_count), fail_msg
+
+    indent_level += 1 if line.end_with? '{'
   end
 end
 


### PR DESCRIPTION
Class constants were indented one level too low. This change adds a test for basic indentation in generated source files, as well as a fix for the indentation of constants.