### PR TITLE
allow string include list

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,3 +6,6 @@ Metrics/ClassLength:
 
 Metrics/MethodLength:
   Max: 55
+
+Style/Documentation:
+  Enabled: false

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,10 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Python class generation.
  - Perl class generation.
 
-## [0.3.0] - 2019-07-07
+## [0.3.0] - 2019-07-08
 ### Added
  - Examples of basic usage and features.
  - Option to give a class-level include list.
+ - Include lists may now be either a single string or a list.
 
 ### Fixed
  - `bin/wrapture` is now executable.

--- a/docs/examples/basic/README.md
+++ b/docs/examples/basic/README.md
@@ -30,8 +30,7 @@ with a few basic attributes:
 classes:
   - name: "Stove"
     namespace: "kitchen"
-    includes:
-      - "stove.h"
+    includes: "stove.h"
 ```
 
 We describe the underlying struct by simply giving its name:
@@ -42,10 +41,11 @@ We describe the underlying struct by simply giving its name:
 ```
 
 For most elements within Wrapture, you may also specify an `includes` list of
-header files necessary for the element, in this case the struct. Doing this for
-each element will result in more efficient header lists and compilation times in
-some cases, but this can be tedious. Specifying this at the class level, as we
-do above, is easier and less verbose.
+header files necessary for the element, in this case the struct. You can make
+this field a list of files if you need more than one for a given element. Doing
+this for each element will result in more efficient header lists and compilation
+times in some cases, but this can be tedious. Specifying this at the class
+level, as we do above, is easier and less verbose.
 
 Next, we describe our only constructor function. We'll do this by specifying
 its name, parameters, and return type:

--- a/docs/examples/basic/stove.yml
+++ b/docs/examples/basic/stove.yml
@@ -1,8 +1,7 @@
 classes:
   - name: "Stove"
     namespace: "kitchen"
-    includes:
-      - "stove.h"
+    includes: "stove.h"
     equivalent-struct:
       name: "stove"
     constructors:

--- a/docs/examples/struct_wrapper/README.md
+++ b/docs/examples/struct_wrapper/README.md
@@ -26,8 +26,7 @@ classes:
     namespace: "soccer"
     equivalent-struct:
       name: "player_stats"
-      includes:
-        - "stats.h"
+      includes: "stats.h"
       members:
         - name: "goals_scored"
           type: "int"
@@ -60,8 +59,7 @@ function called `Print`:
           name: "print_player_stats"
           params:
             - name: "equivalent-struct-pointer"
-          includes:
-            - "stats.h"
+          includes: "stats.h"
 ```
 
 All of this results in a C++ class with the following signature.

--- a/docs/examples/struct_wrapper/stats.yml
+++ b/docs/examples/struct_wrapper/stats.yml
@@ -3,8 +3,7 @@ classes:
     namespace: "soccer"
     equivalent-struct:
       name: "player_stats"
-      includes:
-        - "stats.h"
+      includes: "stats.h"
       members:
         - name: "goals_scored"
           type: "int"
@@ -18,5 +17,4 @@ classes:
           name: "print_player_stats"
           params:
             - name: "equivalent-struct-pointer"
-          includes:
-            - "stats.h"
+          includes: "stats.h"

--- a/lib/wrapture.rb
+++ b/lib/wrapture.rb
@@ -5,5 +5,6 @@ module Wrapture
   require 'wrapture/constant_spec'
   require 'wrapture/class_spec'
   require 'wrapture/function_spec'
+  require 'wrapture/normalize'
   require 'wrapture/version'
 end

--- a/lib/wrapture/class_spec.rb
+++ b/lib/wrapture/class_spec.rb
@@ -15,7 +15,10 @@ module Wrapture
       normalized_spec = spec.dup
       normalized_spec.default = []
 
-      normalized_spec['includes'] ||= []
+      if spec['includes'].is_a? String
+        normalized_spec['includes'] = [spec['includes']]
+      end
+
       normalized_spec['includes'].uniq!
 
       normalized_spec['equivalent-struct']['members'] ||= []

--- a/lib/wrapture/class_spec.rb
+++ b/lib/wrapture/class_spec.rb
@@ -12,20 +12,18 @@ module Wrapture
     # missing keys to their default values (for example, an empty list if no
     # includes are given).
     def self.normalize_spec_hash(spec)
-      normalized_spec = spec.dup
-      normalized_spec.default = []
+      normalized = spec.dup
+      normalized.default = []
 
-      if spec['includes'].is_a? String
-        normalized_spec['includes'] = [spec['includes']]
-      end
+      normalized['includes'] = Wrapture.normalize_includes spec['includes']
 
-      normalized_spec['includes'].uniq!
+      normalized['equivalent-struct']['members'] ||= []
 
-      normalized_spec['equivalent-struct']['members'] ||= []
-      normalized_spec['equivalent-struct']['includes'] ||= []
-      normalized_spec['equivalent-struct']['includes'].uniq!
+      original_includes = spec['equivalent-struct']['includes']
+      includes = Wrapture.normalize_includes original_includes
+      normalized['equivalent-struct']['includes'] = includes
 
-      normalized_spec
+      normalized
     end
 
     # Returns a string of the variable with it's type, properly formatted.

--- a/lib/wrapture/constant_spec.rb
+++ b/lib/wrapture/constant_spec.rb
@@ -8,12 +8,11 @@ module Wrapture
     # will set missing keys to their default value (for example, an empty list
     # if no includes are given).
     def self.normalize_spec_hash(spec)
-      normalized_spec = spec.dup
+      normalized = spec.dup
 
-      normalized_spec['includes'] ||= []
-      normalized_spec['includes'].uniq!
+      normalized['includes'] = Wrapture.normalize_includes spec['includes']
 
-      normalized_spec
+      normalized
     end
 
     # Creates a constant spec based on the provided hash spec

--- a/lib/wrapture/function_spec.rb
+++ b/lib/wrapture/function_spec.rb
@@ -9,20 +9,24 @@ module Wrapture
     # set missing keys to their default values (for example, an empty list if no
     # includes are given).
     def self.normalize_spec_hash(spec)
-      normalized_spec = spec.dup
+      normalized = spec.dup
 
-      normalized_spec['params'] ||= []
-      normalized_spec['wrapped-function']['params'] ||= []
-      normalized_spec['wrapped-function']['includes'] ||= []
+      normalized['params'] ||= []
+      normalized['wrapped-function']['params'] ||= []
 
-      if normalized_spec['return'].nil?
-        normalized_spec['return'] = {}
-        normalized_spec['return']['type'] = 'void'
+      original_includes = spec['wrapped-function']['includes']
+      includes = Wrapture.normalize_includes original_includes
+      normalized['wrapped-function']['includes'] = includes
+      if normalized['return'].nil?
+        normalized['return'] = {}
+        normalized['return']['type'] = 'void'
+        normalized['return']['includes'] = []
+      else
+        includes = Wrapture.normalize_includes spec['return']['includes']
+        normalized['return']['includes'] = includes
       end
 
-      normalized_spec['return']['includes'] ||= []
-
-      normalized_spec
+      normalized
     end
 
     # A comma-separated string of each parameter with its type, suitable for use

--- a/lib/wrapture/normalize.rb
+++ b/lib/wrapture/normalize.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Wrapture
+  # Normalizes an include list for an element. A single string will be converted
+  # into an array containing the single string, and a nil will be converted to
+  # an empty array.
+  def self.normalize_includes(includes)
+    if includes.nil?
+      []
+    elsif includes.is_a? String
+      [includes]
+    else
+      includes.uniq
+    end
+  end
+end

--- a/test/fixtures/basic_class.yml
+++ b/test/fixtures/basic_class.yml
@@ -2,8 +2,7 @@ name: "BasicClass"
 includes: "class_include.h"
 equivalent-struct:
   name: "basic_struct"
-  includes:
-    - "folder/include_file_1.h"
+  includes: "folder/include_file_1.h"
 functions:
   - name: "BasicFunction1"
     params:
@@ -13,6 +12,7 @@ functions:
       name: "underlying_basic_function"
       includes:
         - "folder/include_file_2.h"
+        - "folder/include_file_3.h"
       params:
         - name: "equivalent-struct-pointer"
         - name: "app_name"

--- a/test/fixtures/basic_class.yml
+++ b/test/fixtures/basic_class.yml
@@ -1,6 +1,5 @@
 name: "BasicClass"
-includes:
-  - "class_include.h"
+includes: "class_include.h"
 equivalent-struct:
   name: "basic_struct"
   includes:

--- a/test/fixtures/constant_class.yml
+++ b/test/fixtures/constant_class.yml
@@ -5,3 +5,4 @@ constants:
   - name: "TEST_CONSTANT"
     type: "int"
     value: "3"
+    includes: "my_include.h"

--- a/test/fixtures/constructor_class.yml
+++ b/test/fixtures/constructor_class.yml
@@ -14,8 +14,7 @@ constructors:
           type: "const char *"
       return:
         type: "equivalent-struct-pointer"
-      includes:
-        - "constructed.h"
+      includes: "constructed.h"
   - wrapped-function:
       name: "copy_struct"
       params:
@@ -23,6 +22,8 @@ constructors:
           type: "equivalent-struct"
       return:
         type: "equivalent-struct-pointer"
+      includes:
+        - "constructed.h"
   - wrapped-function:
       name: "copy_struct_pointer"
       params:

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -15,6 +15,7 @@ rescue LoadError
 end
 
 require 'minitest/autorun'
+require 'wrapture'
 
 def get_include_list(filename)
   includes = []
@@ -29,7 +30,7 @@ end
 
 def validate_declaration_file(spec)
   filename = "#{spec['name']}.hpp"
-  class_includes = spec['includes'] || []
+  class_includes =  Wrapture::ClassSpec.normalize_spec_hash(spec)['includes']
 
   includes = get_include_list filename
 
@@ -42,7 +43,7 @@ end
 
 def validate_definition_file(spec)
   filename = "#{spec['name']}.cpp"
-  class_includes = spec['includes'] || []
+  class_includes =  Wrapture::ClassSpec.normalize_spec_hash(spec)['includes']
 
   includes = get_include_list filename
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -30,7 +30,7 @@ end
 
 def validate_declaration_file(spec)
   filename = "#{spec['name']}.hpp"
-  class_includes =  Wrapture::ClassSpec.normalize_spec_hash(spec)['includes']
+  class_includes = Wrapture::ClassSpec.normalize_spec_hash(spec)['includes']
 
   includes = get_include_list filename
 
@@ -43,7 +43,7 @@ end
 
 def validate_definition_file(spec)
   filename = "#{spec['name']}.cpp"
-  class_includes =  Wrapture::ClassSpec.normalize_spec_hash(spec)['includes']
+  class_includes = Wrapture::ClassSpec.normalize_spec_hash(spec)['includes']
 
   includes = get_include_list filename
 


### PR DESCRIPTION
In many cases the include list for an element is a single file. In cases like this, it is more convenient to simply specify a string for the include list rather than define a list of one element. This change gives this option to the user, normalizing the list on the back end.