### PR TITLE
create StructSpec class

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,11 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Python class generation.
  - Perl class generation.
 
-## [0.3.0] - 2019-07-08
+## [0.3.0] - 2019-07-12
 ### Added
  - Examples of basic usage and features.
  - Option to give a class-level include list.
  - Include lists may now be either a single string or a list.
+ - Structs are now described in the StructSpec class.
 
 ### Fixed
  - `bin/wrapture` is now executable.

--- a/lib/wrapture.rb
+++ b/lib/wrapture.rb
@@ -6,5 +6,6 @@ module Wrapture
   require 'wrapture/class_spec'
   require 'wrapture/function_spec'
   require 'wrapture/normalize'
+  require 'wrapture/struct_spec'
   require 'wrapture/version'
 end

--- a/lib/wrapture/struct_spec.rb
+++ b/lib/wrapture/struct_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module Wrapture
+  # A description of a struct.
+  class StructSpec
+    # Normalizes a hash specification of a struct. Normalization will check for
+    # things like invalid keys, duplicate entries in include lists, and will set
+    # missing keys to their default value (for example, an empty list if no
+    # includes are given).
+    def self.normalize_spec_hash(spec)
+      normalized = spec.dup
+      normalized.default = []
+
+      normalized['includes'] = Wrapture.normalize_includes spec['includes']
+
+      normalized['members'] ||= []
+
+      normalized
+    end
+
+    # A declaration of the struct with the given variable name.
+    def declaration(name)
+      "struct #{@spec['name']} #{name}"
+    end
+
+    # A list of includes required for this struct.
+    def includes
+      @spec['includes'].dup
+    end
+
+    # Creates a struct spec based on the provided spec hash.
+    #
+    # The hash must have the following keys:
+    # name:: the name of the struct
+    #
+    # The following keys are optional:
+    # includes:: a list of includes required for the struct
+    # members:: a list of the members of the struct, each with a type and name
+    # field
+    def initialize(spec)
+      @spec = StructSpec.normalize_spec_hash spec
+    end
+
+    # A string containing the typed members of the struct, separated by commas.
+    def member_list
+      members = []
+
+      @spec['members'].each do |member|
+        members << ClassSpec.typed_variable(member['type'], member['name'])
+      end
+
+      members.join ', '
+    end
+
+    # The members of the struct
+    def members
+      @spec['members']
+    end
+
+    # True if there are members included in the struct specification.
+    def members?
+      not @spec['members'].empty?
+    end
+
+    # A declaration of a pointer to the struct with the given variable name.
+    def pointer_declaration(name)
+      "struct #{@spec['name']} *#{name}"
+    end
+  end
+end

--- a/lib/wrapture/struct_spec.rb
+++ b/lib/wrapture/struct_spec.rb
@@ -59,7 +59,7 @@ module Wrapture
 
     # True if there are members included in the struct specification.
     def members?
-      not @spec['members'].empty?
+      !@spec['members'].empty?
     end
 
     # A declaration of a pointer to the struct with the given variable name.

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -48,12 +48,7 @@ def validate_declaration_file(spec)
 
   validate_indentation filename
 
-  if spec['equivalent-struct']['members']
-    first_member_name = spec['equivalent-struct']['members'][0]['name']
-
-    fail_msg = "no constructor for struct members generated"
-    assert file_contains_match(filename, "#{first_member_name}"), fail_msg
-  end
+  validate_members(spec, filename)
 end
 
 def validate_definition_file(spec)
@@ -94,6 +89,15 @@ def validate_indentation(filename)
 
     indent_level += 1 if line.end_with? '{'
   end
+end
+
+def validate_members(spec, filename)
+  return unless spec['equivalent-struct']['members']
+
+  first_member_name = spec['equivalent-struct']['members'][0]['name']
+
+  fail_msg = 'no constructor for struct members generated'
+  assert file_contains_match(filename, first_member_name), fail_msg
 end
 
 def validate_wrapper_results(spec, file_list)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -17,6 +17,14 @@ end
 require 'minitest/autorun'
 require 'wrapture'
 
+def file_contains_match(filename, regex)
+  File.open(filename).each do |line|
+    return true if line.match(regex)
+  end
+
+  false
+end
+
 def get_include_list(filename)
   includes = []
   File.open(filename).each do |line|
@@ -39,6 +47,13 @@ def validate_declaration_file(spec)
   end
 
   validate_indentation filename
+
+  if spec['equivalent-struct']['members']
+    first_member_name = spec['equivalent-struct']['members'][0]['name']
+
+    fail_msg = "no constructor for struct members generated"
+    assert file_contains_match(filename, "#{first_member_name}"), fail_msg
+  end
 end
 
 def validate_definition_file(spec)


### PR DESCRIPTION
While other members of class specifications were handled in classes, the description of the equivalent structs was still handled with a hash. This change factors the struct descriptions into their own class and pushes the related functionality there.