### PR TITLE
fix bad namespace generation

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
  - `bin/wrapture` is now executable.
  - Class constants are indented properly.
+ - Missing namespaces are caught before code generation.
 
 ## [0.2.2] - 2019-07-06
 ### Fixed

--- a/lib/wrapture.rb
+++ b/lib/wrapture.rb
@@ -4,6 +4,7 @@
 module Wrapture
   require 'wrapture/constant_spec'
   require 'wrapture/class_spec'
+  require 'wrapture/errors'
   require 'wrapture/function_spec'
   require 'wrapture/normalize'
   require 'wrapture/struct_spec'

--- a/lib/wrapture/class_spec.rb
+++ b/lib/wrapture/class_spec.rb
@@ -12,6 +12,8 @@ module Wrapture
     # missing keys to their default values (for example, an empty list if no
     # includes are given).
     def self.normalize_spec_hash(spec)
+      raise NoNamespace if !spec.key?('namespace')
+
       normalized = spec.dup
       normalized.default = []
 

--- a/lib/wrapture/class_spec.rb
+++ b/lib/wrapture/class_spec.rb
@@ -12,7 +12,7 @@ module Wrapture
     # missing keys to their default values (for example, an empty list if no
     # includes are given).
     def self.normalize_spec_hash(spec)
-      raise NoNamespace if !spec.key?('namespace')
+      raise NoNamespace unless spec.key?('namespace')
 
       normalized = spec.dup
       normalized.default = []

--- a/lib/wrapture/errors.rb
+++ b/lib/wrapture/errors.rb
@@ -4,4 +4,8 @@ module Wrapture
   # An error from the Wrapture library
   class WraptureError < StandardError
   end
+
+  # Missing a namespace in the class spec
+  class NoNamespace < WraptureError
+  end
 end

--- a/lib/wrapture/errors.rb
+++ b/lib/wrapture/errors.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Wrapture
+  # An error from the Wrapture library
+  class WraptureError < StandardError
+  end
+end

--- a/test/fixtures/basic_class.yml
+++ b/test/fixtures/basic_class.yml
@@ -1,4 +1,5 @@
 name: "BasicClass"
+namespace: "wrapture_test"
 includes: "class_include.h"
 equivalent-struct:
   name: "basic_struct"

--- a/test/fixtures/constant_class.yml
+++ b/test/fixtures/constant_class.yml
@@ -1,4 +1,5 @@
 name: "ClassWithConstant"
+namespace: "wrapture_test"
 equivalent-struct:
   name: "basic_struct"
 constants:

--- a/test/fixtures/constructor_class.yml
+++ b/test/fixtures/constructor_class.yml
@@ -1,4 +1,5 @@
 name: "ClassWithConstructor"
+namespace: "wrapture_test"
 equivalent-struct:
   name: "constructed_struct"
   members:

--- a/test/fixtures/invalid/no_namespace.yml
+++ b/test/fixtures/invalid/no_namespace.yml
@@ -1,0 +1,4 @@
+name: "NoNamespace"
+equivalent-struct:
+  name: "struct_name"
+  includes: "struct_file.h"

--- a/test/fixtures/minimal_class.yml
+++ b/test/fixtures/minimal_class.yml
@@ -1,3 +1,4 @@
 name: "MinimalClass"
+namespace: "wrapture_test"
 equivalent-struct:
   name: "minimal_struct"

--- a/test/fixtures/static_function_class.yml
+++ b/test/fixtures/static_function_class.yml
@@ -1,4 +1,5 @@
 name: "ClassWithStaticFunction"
+namespace: "wrapture_test"
 equivalent-struct:
   name: "basic_struct"
 functions:

--- a/test/fixtures/struct_wrapper_class.yml
+++ b/test/fixtures/struct_wrapper_class.yml
@@ -1,4 +1,5 @@
 name: "StructWrapperClass"
+namespace: "wrapture_test"
 equivalent-struct:
   name: "struct_to_wrap"
   includes:

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -102,7 +102,7 @@ def validate_members(spec, filename)
 end
 
 def validate_namespace(spec, filename)
-  assert file_contains_match(filename, "namespace \w+"), "namespace was invalid"
+  assert file_contains_match(filename, /namespace \w+/), 'namespace was invalid'
   assert file_contains_match(filename, "namespace #{spec['namespace']}")
 end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -47,8 +47,8 @@ def validate_declaration_file(spec)
   end
 
   validate_indentation filename
-
   validate_members(spec, filename)
+  validate_namespace(spec, filename)
 end
 
 def validate_definition_file(spec)
@@ -62,6 +62,7 @@ def validate_definition_file(spec)
   end
 
   validate_indentation filename
+  validate_namespace(spec, filename)
 end
 
 def validate_indentation(filename)
@@ -98,6 +99,11 @@ def validate_members(spec, filename)
 
   fail_msg = 'no constructor for struct members generated'
   assert file_contains_match(filename, first_member_name), fail_msg
+end
+
+def validate_namespace(spec, filename)
+  assert file_contains_match(filename, "namespace \w+")
+  assert file_contains_match(filename, "namespace #{spec['namespace']}")
 end
 
 def validate_wrapper_results(spec, file_list)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -102,7 +102,7 @@ def validate_members(spec, filename)
 end
 
 def validate_namespace(spec, filename)
-  assert file_contains_match(filename, "namespace \w+")
+  assert file_contains_match(filename, "namespace \w+"), "namespace was invalid"
   assert file_contains_match(filename, "namespace #{spec['namespace']}")
 end
 

--- a/test/test_invalid.rb
+++ b/test/test_invalid.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'helper'
+
+require 'minitest/autorun'
+require 'wrapture'
+
+class InvalidTest < Minitest::Test
+  def test_no_namespace
+    test_spec = load_fixture 'invalid/no_namespace'
+
+    assert_raises(Wrapture::WraptureError) do
+      Wrapture::ClassSpec.new test_spec
+    end
+  end
+end


### PR DESCRIPTION
Classes with missing namespaces would generate C++ code with a namespace of '[]' which is invalid. This is corrected by checking for the 'namespace' field during code generation and rejecting classes without it.