### PR TITLE
add includes for function parameters

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Python class generation.
  - Perl class generation.
 
-## [0.3.0] - 2019-07-12
+## [0.3.0] - 2019-08-21
 ### Added
  - Examples of basic usage and features.
  - Option to give a class-level include list.
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Structs are now described in the StructSpec class.
  - Installation and dependency notes to README.
  - Scope class to describe a collection of classes.
+ - `includes` property for function parameters.
 
 ### Fixed
  - `bin/wrapture` is now executable.

--- a/test/fixtures/nested_structs.yml
+++ b/test/fixtures/nested_structs.yml
@@ -8,6 +8,7 @@ classes:
         params:
           - name: "new_pool"
             type: "Pool"
+            includes: "Pool.hpp"
         wrapped-function:
           name: "add_pool_to_gym"
           params:
@@ -19,6 +20,7 @@ classes:
         params:
           - name: "original_pool"
             type: "Pool"
+            includes: "Pool.hpp"
         wrapped-function:
           name: "copy_pool_to_gym"
           params:
@@ -30,6 +32,7 @@ classes:
         params:
           - name: "new_track"
             type: "Track"
+            includes: "Track.hpp"
         wrapped-function:
           name: "add_track_to_gym"
           params:
@@ -41,6 +44,7 @@ classes:
         params:
           - name: "original_track"
             type: "Track"
+            includes: "Track.hpp"
         wrapped-function:
           name: "copy_track_to_gym"
           params:

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -40,8 +40,8 @@ def validate_class_wrapper(spec, file_list)
   refute_nil(file_list)
   refute_empty(file_list)
 
-  assert(file_list.include? "#{spec['name']}.cpp")
-  assert(file_list.include? "#{spec['name']}.hpp")
+  assert(file_list.include?("#{spec['name']}.cpp"))
+  assert(file_list.include?("#{spec['name']}.hpp"))
 
   validate_declaration_file(spec)
   validate_definition_file(spec)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -36,6 +36,17 @@ def get_include_list(filename)
   includes
 end
 
+def validate_class_wrapper(spec, file_list)
+  refute_nil(file_list)
+  refute_empty(file_list)
+
+  assert(file_list.include? "#{spec['name']}.cpp")
+  assert(file_list.include? "#{spec['name']}.hpp")
+
+  validate_declaration_file(spec)
+  validate_definition_file(spec)
+end
+
 def validate_declaration_file(spec)
   filename = "#{spec['name']}.hpp"
   class_includes = Wrapture::ClassSpec.normalize_spec_hash(spec)['includes']
@@ -107,12 +118,12 @@ def validate_namespace(spec, filename)
 end
 
 def validate_wrapper_results(spec, file_list)
-  refute_nil file_list
-  refute_empty file_list
-  assert file_list.length == 2
-  assert file_list.include? "#{spec['name']}.cpp"
-  assert file_list.include? "#{spec['name']}.hpp"
-
-  validate_declaration_file(spec)
-  validate_definition_file(spec)
+  if spec.key?('classes')
+    spec['classes'].each do |class_spec|
+      validate_class_wrapper(class_spec, file_list)
+    end
+  else
+    assert(file_list.length == 2, msg: 'only 2 files expected per class')
+    validate_class_wrapper(spec, file_list)
+  end
 end

--- a/test/test_nested_structs.rb
+++ b/test/test_nested_structs.rb
@@ -17,6 +17,10 @@ class NestedStructsTest < Minitest::Test
     generated_files = scope.generate_wrappers
     validate_wrapper_results(test_spec, generated_files)
 
+    includes = get_include_list('Gym.hpp')
+    assert_includes(includes, 'Pool.hpp')
+    assert_includes(includes, 'Track.hpp')
+
     includes = get_include_list('Gym.cpp')
     assert_includes(includes, 'Pool.hpp')
     assert_includes(includes, 'Track.hpp')

--- a/test/test_nested_structs.rb
+++ b/test/test_nested_structs.rb
@@ -15,7 +15,11 @@ class NestedStructsTest < Minitest::Test
     assert_equal(test_spec['classes'].count, scope.classes.count)
 
     generated_files = scope.generate_wrappers
-    assert_equal(scope.classes.count, generated_files.count / 2)
+    validate_wrapper_results(test_spec, generated_files)
+
+    includes = get_include_list('Gym.cpp')
+    assert_includes(includes, 'Pool.hpp')
+    assert_includes(includes, 'Track.hpp')
 
     File.delete(*generated_files)
   end


### PR DESCRIPTION
Allow specification of include lists for function parameters. This facilitates the use of nested structs by making it possible to specify the includes needed for use of a generated class.