### PR TITLE
accept multiple files at once

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Python class generation.
  - Perl class generation.
 
-## [0.3.0] - 2019-08-21
+## [0.3.0] - 2019-08-22
 ### Added
  - Examples of basic usage and features.
  - Option to give a class-level include list.
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Installation and dependency notes to README.
  - Scope class to describe a collection of classes.
  - `includes` property for function parameters.
- - The binary can accept multiple input files.
+ - `bin/wapture` now accepts multiple input files.
 
 ### Fixed
  - `bin/wrapture` is now executable.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Installation and dependency notes to README.
  - Scope class to describe a collection of classes.
  - `includes` property for function parameters.
+ - The binary can accept multiple input files.
 
 ### Fixed
  - `bin/wrapture` is now executable.

--- a/bin/wrapture
+++ b/bin/wrapture
@@ -5,7 +5,11 @@
 require 'yaml'
 require 'wrapture'
 
-spec = YAML.load_file ARGV[0]
+scope = Wrapture::Scope.new
 
-scope = Wrapture::Scope.new(spec)
+ARGV.each do |spec_file|
+  spec = YAML.load_file(spec_file)
+  scope << Wrapture::ClassSpec.new(spec)
+end
+
 scope.generate_wrappers

--- a/bin/wrapture
+++ b/bin/wrapture
@@ -9,7 +9,10 @@ scope = Wrapture::Scope.new
 
 ARGV.each do |spec_file|
   spec = YAML.load_file(spec_file)
-  scope << Wrapture::ClassSpec.new(spec)
+
+  spec['classes'].each do |class_spec|
+    scope << Wrapture::ClassSpec.new(class_spec)
+  end
 end
 
 scope.generate_wrappers


### PR DESCRIPTION
Updates the bin/wrapture script to read multiple specification files in one run. All files are added to a single scope as if they were in the same file.