### PR TITLE
add version checks to specs

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Python class generation.
  - Perl class generation.
 
-## [0.3.0] - 2019-08-24
+## [0.3.0] - 2019-08-23
 ### Added
  - Examples of basic usage and features.
  - Option to give a class-level include list.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Scope class to describe a collection of classes.
  - `includes` property for function parameters.
  - `bin/wapture` now accepts multiple input files.
- - Version field in specs for backwards compatibility.
+ - `version` field in specs for explicit support checks.
 
 ### Fixed
  - `bin/wrapture` is now executable.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Python class generation.
  - Perl class generation.
 
-## [0.3.0] - 2019-07-12
+## [0.3.0] - 2019-08-12
 ### Added
  - Examples of basic usage and features.
  - Option to give a class-level include list.
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Structs are now described in the StructSpec class.
  - Installation and dependency notes to README.
  - Scope class to describe a collection of classes.
+ - Version field in specs for backwards compatibility.
 
 ### Fixed
  - `bin/wrapture` is now executable.

--- a/lib/wrapture/class_spec.rb
+++ b/lib/wrapture/class_spec.rb
@@ -2,7 +2,7 @@
 
 require 'wrapture/constant_spec'
 require 'wrapture/function_spec'
-require 'wrapture/version'
+require 'wrapture/normalize'
 
 module Wrapture
   # A description of a class, including its constants, functions, and other
@@ -18,19 +18,10 @@ module Wrapture
     def self.normalize_spec_hash(spec)
       raise NoNamespace unless spec.key?('namespace')
 
-      if spec.key?('version') && !Wrapture.supports_version?(spec['version'])
-        raise UnsupportedSpecVersion
-      end
-
       normalized = spec.dup
       normalized.default = []
 
-      normalized['version'] = if spec.key?('version')
-                                spec['version']
-                              else
-                                Wrapture::VERSION
-                              end
-
+      normalized['version'] = Wrapture.get_spec_version(spec)
       normalized['includes'] = Wrapture.normalize_includes(spec['includes'])
 
       normalized

--- a/lib/wrapture/class_spec.rb
+++ b/lib/wrapture/class_spec.rb
@@ -21,7 +21,7 @@ module Wrapture
       normalized = spec.dup
       normalized.default = []
 
-      normalized['version'] = Wrapture.get_spec_version(spec)
+      normalized['version'] = Wrapture.spec_version(spec)
       normalized['includes'] = Wrapture.normalize_includes(spec['includes'])
 
       normalized

--- a/lib/wrapture/class_spec.rb
+++ b/lib/wrapture/class_spec.rb
@@ -2,6 +2,7 @@
 
 require 'wrapture/constant_spec'
 require 'wrapture/function_spec'
+require 'wrapture/version'
 
 module Wrapture
   # A description of a class, including its constants, functions, and other
@@ -11,13 +12,26 @@ module Wrapture
     # things like invalid keys, duplicate entries in include lists, and will set
     # missing keys to their default values (for example, an empty list if no
     # includes are given).
+    #
+    # If this spec cannot be normalized, for example because it is invalid or
+    # it uses an unsupported version type, then an exception is raised.
     def self.normalize_spec_hash(spec)
       raise NoNamespace unless spec.key?('namespace')
+
+      if spec.key?('version') && !Wrapture.supports_version?(spec['version'])
+        raise UnsupportedSpecVersion
+      end
 
       normalized = spec.dup
       normalized.default = []
 
-      normalized['includes'] = Wrapture.normalize_includes spec['includes']
+      normalized['version'] = if spec.key?('version')
+                                spec['version']
+                              else
+                                Wrapture::VERSION
+                              end
+
+      normalized['includes'] = Wrapture.normalize_includes(spec['includes'])
 
       normalized
     end

--- a/lib/wrapture/constant_spec.rb
+++ b/lib/wrapture/constant_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'wrapture/normalize'
+
 module Wrapture
   # A description of a constant.
   class ConstantSpec
@@ -10,6 +12,7 @@ module Wrapture
     def self.normalize_spec_hash(spec)
       normalized = spec.dup
 
+      normalized['version'] = Wrapture.spec_version(spec)
       normalized['includes'] = Wrapture.normalize_includes spec['includes']
 
       normalized

--- a/lib/wrapture/errors.rb
+++ b/lib/wrapture/errors.rb
@@ -8,4 +8,8 @@ module Wrapture
   # Missing a namespace in the class spec
   class NoNamespace < WraptureError
   end
+
+  # The spec version is not supported by this version of Wrapture.
+  class UnsupportedSpecVersion < WraptureError
+  end
 end

--- a/lib/wrapture/function_spec.rb
+++ b/lib/wrapture/function_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'wrapture/scope'
+
 module Wrapture
   # A description of a function to be generated, including details about the
   # underlying implementation.
@@ -11,6 +13,8 @@ module Wrapture
     def self.normalize_spec_hash(spec)
       normalized = spec.dup
       param_types = {}
+
+      normalized['version'] = Wrapture.spec_version(spec)
 
       normalized['params'] ||= []
       normalized['params'].each do |param_spec|
@@ -86,7 +90,7 @@ module Wrapture
     #
     # The following keys are optional:
     # static:: set to true if this is a static function.
-    def initialize(spec, owner)
+    def initialize(spec, owner = Scope.new)
       @owner = owner
       @spec = FunctionSpec.normalize_spec_hash(spec)
     end

--- a/lib/wrapture/normalize.rb
+++ b/lib/wrapture/normalize.rb
@@ -1,6 +1,25 @@
 # frozen_string_literal: true
 
+require 'wrapture/version'
+
 module Wrapture
+  # Returns the spec version for the provided spec. If the version is not
+  # provided in the spec, the newest version that the spec is compliant with
+  # will be returned instead. If this spec uses a version unsupported by this
+  # version of Wrapture or the spec is otherwise invalid, an exception is
+  # raised.
+  def self.get_spec_version(spec)
+    if spec.key?('version') && !Wrapture.supports_version?(spec['version'])
+      raise UnsupportedSpecVersion
+    end
+
+    if spec.key?('version')
+      spec['version']
+    else
+      Wrapture::VERSION
+    end
+  end
+
   # Normalizes an include list for an element. A single string will be converted
   # into an array containing the single string, and a nil will be converted to
   # an empty array.

--- a/lib/wrapture/normalize.rb
+++ b/lib/wrapture/normalize.rb
@@ -3,23 +3,6 @@
 require 'wrapture/version'
 
 module Wrapture
-  # Returns the spec version for the provided spec. If the version is not
-  # provided in the spec, the newest version that the spec is compliant with
-  # will be returned instead. If this spec uses a version unsupported by this
-  # version of Wrapture or the spec is otherwise invalid, an exception is
-  # raised.
-  def self.get_spec_version(spec)
-    if spec.key?('version') && !Wrapture.supports_version?(spec['version'])
-      raise UnsupportedSpecVersion
-    end
-
-    if spec.key?('version')
-      spec['version']
-    else
-      Wrapture::VERSION
-    end
-  end
-
   # Normalizes an include list for an element. A single string will be converted
   # into an array containing the single string, and a nil will be converted to
   # an empty array.
@@ -30,6 +13,24 @@ module Wrapture
       [includes]
     else
       includes.uniq
+    end
+  end
+
+  # Returns the spec version for the provided spec. If the version is not
+  # provided in the spec, the newest version that the spec is compliant with
+  # will be returned instead.
+  #
+  # If this spec uses a version unsupported by this version of Wrapture or the
+  # spec is otherwise invalid, an exception is raised.
+  def self.spec_version(spec)
+    if spec.key?('version') && !Wrapture.supports_version?(spec['version'])
+      raise UnsupportedSpecVersion
+    end
+
+    if spec.key?('version')
+      spec['version']
+    else
+      Wrapture::VERSION
     end
   end
 end

--- a/lib/wrapture/scope.rb
+++ b/lib/wrapture/scope.rb
@@ -12,6 +12,7 @@ module Wrapture
 
       return if spec.nil? || !spec.key?('classes')
 
+      @version = Wrapture.spec_version(spec)
       spec['classes'].each do |class_hash|
         ClassSpec.new(class_hash, scope: self)
       end

--- a/lib/wrapture/version.rb
+++ b/lib/wrapture/version.rb
@@ -3,4 +3,13 @@
 module Wrapture
   # the current version of Wrapture
   VERSION = '0.3.0'
+
+  # Returns true if the version of the spec is supported by this version of
+  # Wrapture. Otherwise returns false.
+  def self.supports_version?(version)
+    wrapture_version = Gem::Version.new(Wrapture::VERSION)
+    spec_version = Gem::Version.new(version)
+
+    spec_version <= wrapture_version
+  end
 end

--- a/test/fixtures/basic_constant.yml
+++ b/test/fixtures/basic_constant.yml
@@ -1,0 +1,4 @@
+name: "TEST_CONSTANT"
+type: "int"
+value: "455"
+includes: "my_include.h"

--- a/test/fixtures/basic_function.yml
+++ b/test/fixtures/basic_function.yml
@@ -1,0 +1,12 @@
+name: "BasicFunction1"
+params:
+  - name: "app_name"
+    type: "const char *"
+wrapped-function:
+  name: "underlying_basic_function"
+  includes:
+    - "folder/include_file_2.h"
+    - "folder/include_file_3.h"
+  params:
+    - name: "equivalent-struct-pointer"
+    - name: "app_name"

--- a/test/fixtures/future_version_class.yml
+++ b/test/fixtures/future_version_class.yml
@@ -1,0 +1,5 @@
+name: "MinimalClass"
+version: "99.0.0"
+namespace: "wrapture_test"
+equivalent-struct:
+  name: "minimal_struct"

--- a/test/fixtures/future_version_constant.yml
+++ b/test/fixtures/future_version_constant.yml
@@ -1,0 +1,5 @@
+name: "TEST_CONSTANT"
+version: "99.0.0"
+type: "int"
+value: "455"
+includes: "my_include.h"

--- a/test/fixtures/future_version_function.yml
+++ b/test/fixtures/future_version_function.yml
@@ -1,0 +1,13 @@
+name: "BasicFunction1"
+version: "99.0.0"
+params:
+  - name: "app_name"
+    type: "const char *"
+wrapped-function:
+  name: "underlying_basic_function"
+  includes:
+    - "folder/include_file_2.h"
+    - "folder/include_file_3.h"
+  params:
+    - name: "equivalent-struct-pointer"
+    - name: "app_name"

--- a/test/fixtures/future_version_scope.yml
+++ b/test/fixtures/future_version_scope.yml
@@ -1,0 +1,10 @@
+version: "99.0.0"
+classes:
+  - name: "MinimalClassOne"
+    namespace: "wrapture_test"
+    equivalent-struct:
+      name: "minimal_struct_one"
+  - name: "MinimalClassTwo"
+    namespace: "wrapture_test"
+    equivalent-struct:
+      name: "minimal_struct_two"

--- a/test/fixtures/versioned_class.yml
+++ b/test/fixtures/versioned_class.yml
@@ -1,0 +1,5 @@
+name: "MinimalClass"
+version: "0.2.0"
+namespace: "wrapture_test"
+equivalent-struct:
+  name: "minimal_struct"

--- a/test/fixtures/versioned_constant.yml
+++ b/test/fixtures/versioned_constant.yml
@@ -1,0 +1,5 @@
+name: "TEST_CONSTANT"
+version: "0.2.0"
+type: "int"
+value: "455"
+includes: "my_include.h"

--- a/test/fixtures/versioned_function.yml
+++ b/test/fixtures/versioned_function.yml
@@ -1,0 +1,13 @@
+name: "BasicFunction1"
+version: "0.2.0"
+params:
+  - name: "app_name"
+    type: "const char *"
+wrapped-function:
+  name: "underlying_basic_function"
+  includes:
+    - "folder/include_file_2.h"
+    - "folder/include_file_3.h"
+  params:
+    - name: "equivalent-struct-pointer"
+    - name: "app_name"

--- a/test/fixtures/versioned_scope.yml
+++ b/test/fixtures/versioned_scope.yml
@@ -1,0 +1,10 @@
+version: "0.2.0"
+classes:
+  - name: "MinimalClassOne"
+    namespace: "wrapture_test"
+    equivalent-struct:
+      name: "minimal_struct_one"
+  - name: "MinimalClassTwo"
+    namespace: "wrapture_test"
+    equivalent-struct:
+      name: "minimal_struct_two"

--- a/test/test_class_spec.rb
+++ b/test/test_class_spec.rb
@@ -15,6 +15,14 @@ class ClassSpecTest < Minitest::Test
     refute_nil normalized_spec
   end
 
+  def test_future_spec_version
+    test_spec = load_fixture('future_version_class')
+
+    assert_raises(Wrapture::UnsupportedSpecVersion) do
+      Wrapture::ClassSpec.new(test_spec)
+    end
+  end
+
   def test_generate_wrappers
     test_spec = load_fixture('basic_class')
 
@@ -61,6 +69,17 @@ class ClassSpecTest < Minitest::Test
       static_function_found = true if line.include? 'static'
     end
     assert static_function_found, 'No static function defined.'
+
+    File.delete(*classes)
+  end
+
+  def test_versioned_class
+    test_spec = load_fixture('versioned_class')
+
+    spec = Wrapture::ClassSpec.new(test_spec)
+
+    classes = spec.generate_wrappers
+    validate_wrapper_results(test_spec, classes)
 
     File.delete(*classes)
   end

--- a/test/test_constant_spec.rb
+++ b/test/test_constant_spec.rb
@@ -10,7 +10,7 @@ class ConstantSpecTest < Minitest::Test
   def test_basic_new
     test_spec = load_fixture('basic_constant')
 
-    constant = Wrapture::ConstantSpec.new(test_spec)
+    Wrapture::ConstantSpec.new(test_spec)
   end
 
   def test_future_spec_version
@@ -24,6 +24,6 @@ class ConstantSpecTest < Minitest::Test
   def test_versioned_constant
     test_spec = load_fixture('basic_constant')
 
-    constant = Wrapture::ConstantSpec.new(test_spec)
+    Wrapture::ConstantSpec.new(test_spec)
   end
 end

--- a/test/test_constant_spec.rb
+++ b/test/test_constant_spec.rb
@@ -22,7 +22,7 @@ class ConstantSpecTest < Minitest::Test
   end
 
   def test_versioned_constant
-    test_spec = load_fixture('basic_constant')
+    test_spec = load_fixture('versioned_constant')
 
     Wrapture::ConstantSpec.new(test_spec)
   end

--- a/test/test_constant_spec.rb
+++ b/test/test_constant_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'helper'
+
+require 'fixture'
+require 'minitest/autorun'
+require 'wrapture'
+
+class ConstantSpecTest < Minitest::Test
+  def test_basic_new
+    test_spec = load_fixture('basic_constant')
+
+    constant = Wrapture::ConstantSpec.new(test_spec)
+  end
+
+  def test_future_spec_version
+    test_spec = load_fixture('future_version_constant')
+
+    assert_raises(Wrapture::UnsupportedSpecVersion) do
+      Wrapture::ConstantSpec.new(test_spec)
+    end
+  end
+
+  def test_versioned_constant
+    test_spec = load_fixture('basic_constant')
+
+    constant = Wrapture::ConstantSpec.new(test_spec)
+  end
+end

--- a/test/test_function_spec.rb
+++ b/test/test_function_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'helper'
+
+require 'fixture'
+require 'minitest/autorun'
+require 'wrapture'
+
+class FunctionSpecTest < Minitest::Test
+  def test_basic_new
+    test_spec = load_fixture('basic_function')
+
+    Wrapture::FunctionSpec.new(test_spec)
+  end
+
+  def test_future_spec_version
+    test_spec = load_fixture('future_version_function')
+
+    assert_raises(Wrapture::UnsupportedSpecVersion) do
+      Wrapture::FunctionSpec.new(test_spec)
+    end
+  end
+
+  def test_versioned_function
+    test_spec = load_fixture('versioned_function')
+
+    Wrapture::FunctionSpec.new(test_spec)
+  end
+end

--- a/test/test_scope.rb
+++ b/test/test_scope.rb
@@ -7,8 +7,29 @@ require 'minitest/autorun'
 require 'wrapture'
 
 class ScopeTest < Minitest::Test
-  def test_minimal
+  def test_future_scope_version
+    test_spec = load_fixture('future_version_scope')
+
+    assert_raises(Wrapture::UnsupportedSpecVersion) do
+      Wrapture::Scope.new(test_spec)
+    end
+  end
+
+  def test_minimal_scope
     test_spec = load_fixture('minimal_scope')
+
+    scope = Wrapture::Scope.new(test_spec)
+
+    assert_equal(test_spec['classes'].count, scope.classes.count)
+
+    generated_files = scope.generate_wrappers
+    assert_equal(scope.classes.count, generated_files.count / 2)
+
+    File.delete(*generated_files)
+  end
+
+  def test_versioned_scope
+    test_spec = load_fixture('versioned_scope')
 
     scope = Wrapture::Scope.new(test_spec)
 


### PR DESCRIPTION
Adds an optional version field to scope, class, function, and constant specifications. This allows the library to detect when a specification built for a newer version is being used and raise an error if so.