### PR TITLE
fix bin/wrapture nested struct support

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Python class generation.
  - Perl class generation.
 
-## [0.3.0] - 2019-08-24
+## [0.3.0] - 2019-08-23
 ### Added
  - Examples of basic usage and features.
  - Option to give a class-level include list.
@@ -20,7 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - `includes` property for function parameters.
  - `bin/wapture` now accepts multiple input files.
  - `version` field in specs for explicit support checks.
- - `value` property for wrapped function parameters.
 
 ### Fixed
  - `bin/wrapture` is now executable.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Python class generation.
  - Perl class generation.
 
-## [0.3.0] - 2019-07-12
+## [0.3.0] - 2019-08-13
 ### Added
  - Examples of basic usage and features.
  - Option to give a class-level include list.
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Structs are now described in the StructSpec class.
  - Installation and dependency notes to README.
  - Scope class to describe a collection of classes.
+ - `value` property for wrapped function parameters.
 
 ### Fixed
  - `bin/wrapture` is now executable.

--- a/bin/wrapture
+++ b/bin/wrapture
@@ -11,7 +11,7 @@ ARGV.each do |spec_file|
   spec = YAML.load_file(spec_file)
 
   spec['classes'].each do |class_spec|
-    scope << Wrapture::ClassSpec.new(class_spec)
+    Wrapture::ClassSpec.new(class_spec, scope: scope)
   end
 end
 

--- a/lib/wrapture/scope.rb
+++ b/lib/wrapture/scope.rb
@@ -19,6 +19,9 @@ module Wrapture
     end
 
     # Adds a class specification to the scope.
+    #
+    # This does not set the scope as the owner of the class. This must be done
+    # during the construction of the class spec.
     def <<(spec)
       @classes << spec if spec.is_a?(ClassSpec)
     end


### PR DESCRIPTION
The scope was not properly set in the bin/wrapture, which caused nested structs to not be properly cast. This is fixed by setting the scope in the constructor of each class spec when it is parsed.