### PR TITLE
refactor constructor and destructors

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Python class generation.
  - Perl class generation.
 
-## [0.3.0] - 2019-08-24
+## [0.3.0] - 2019-09-02
 ### Added
  - Examples of basic usage and features.
  - Option to give a class-level include list.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,12 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Python class generation.
  - Perl class generation.
 
-## [0.3.0] - 2019-08-23
+## [0.3.0] - 2019-08-24
 ### Added
  - Examples of basic usage and features.
  - Option to give a class-level include list.
  - Include lists may now be either a single string or a list.
  - Structs are now described in the StructSpec class.
+ - Wrapped functions are now described in the WrappedFunctionSpec class.
  - Installation and dependency notes to README.
  - Scope class to describe a collection of classes.
  - `includes` property for function parameters.

--- a/lib/wrapture.rb
+++ b/lib/wrapture.rb
@@ -3,6 +3,7 @@
 # Classes and functions for generating language wrappers
 module Wrapture
   require 'wrapture/constant_spec'
+  require 'wrapture/constants'
   require 'wrapture/class_spec'
   require 'wrapture/errors'
   require 'wrapture/function_spec'

--- a/lib/wrapture/class_spec.rb
+++ b/lib/wrapture/class_spec.rb
@@ -57,18 +57,18 @@ module Wrapture
 
       @functions = []
       @spec['constructors'].each do |constructor_spec|
-        function_spec = constructor_spec.dup
-        function_spec['name'] = @spec['name']
-        function_spec['params'] = constructor_spec['wrapped-function']['params']
+        full_spec = constructor_spec.dup
+        full_spec['name'] = @spec['name']
+        full_spec['params'] = constructor_spec['wrapped-function']['params']
 
-        @functions << FunctionSpec.new(function_spec, self, constructor: true)
+        @functions << FunctionSpec.new(full_spec, self, constructor: true)
       end
 
       if @spec.key?('destructor')
-        function_spec = @spec['destructor'].dup
-        function_spec['name'] = "~#{@spec['name']}"
+        destructor_spec = @spec['destructor'].dup
+        destructor_spec['name'] = "~#{@spec['name']}"
 
-        @functions << FunctionSpec.new(function_spec, self, destructor: true)
+        @functions << FunctionSpec.new(destructor_spec, self, destructor: true)
       end
 
       @spec['functions'].each do |function_spec|

--- a/lib/wrapture/class_spec.rb
+++ b/lib/wrapture/class_spec.rb
@@ -126,19 +126,6 @@ module Wrapture
       @spec['name']
     end
 
-    # Returns a string for the provided parameter that can be used within the
-    # class's code.
-    def resolve_param(param)
-      case param
-      when 'equivalent-struct'
-        this_struct
-      when 'equivalent-struct-pointer'
-        this_struct_pointer
-      else
-        param
-      end
-    end
-
     # The name of the equivalent struct of this class.
     def struct_name
       @struct.name
@@ -172,17 +159,6 @@ module Wrapture
     # Returns true if the given type exists in this class's scope.
     def type?(type)
       @scope.type?(type)
-    end
-
-    # A string calling the wrapped function spec, with resolved parameters.
-    def function_call(spec)
-      resolved_params = []
-
-      spec['params'].each do |param|
-        resolved_params << resolve_param(param['name'])
-      end
-
-      "#{spec['name']}( #{resolved_params.join ', '} )"
     end
 
     private
@@ -256,11 +232,6 @@ module Wrapture
       end
     end
 
-    # The signature of the destructor.
-    def destructor_signature
-      "~#{@spec['name']}( void )"
-    end
-
     # The definition of the member constructor for a class. This is only valid
     # when the class is not a pointer wrapper.
     def member_constructor_signature
@@ -321,8 +292,6 @@ module Wrapture
         yield "    #{struct_constructor_signature};"
         yield "    #{pointer_constructor_signature};"
       end
-
-      yield "    #{destructor_signature};" if @spec.key? 'destructor'
 
       @functions.each do |func|
         yield "    #{func.declaration};"
@@ -393,14 +362,6 @@ module Wrapture
           yield "    #{member_decl} = equivalent->#{member['name']};"
         end
 
-        yield '  }'
-      end
-
-      if @spec.key? 'destructor'
-        yield
-        yield "  #{@spec['name']}::#{destructor_signature} {"
-        func_spec = @spec['destructor']['wrapped-function']
-        yield "    #{function_call func_spec};"
         yield '  }'
       end
 

--- a/lib/wrapture/class_spec.rb
+++ b/lib/wrapture/class_spec.rb
@@ -249,32 +249,9 @@ module Wrapture
       end
     end
 
-    # Gives the signature of a constructor, based on its index in the class
-    # specification.
-    def wrapped_constructor_signature(index)
-      function_spec = @spec['constructors'][index]['wrapped-function']
-
-      "#{@spec['name']}( #{FunctionSpec.param_list function_spec} )"
-    end
-
     # The signature of the destructor.
     def destructor_signature
       "~#{@spec['name']}( void )"
-    end
-
-    # The definition of a constructor, based on its index in the class
-    # specification.
-    def wrapped_constructor_definition(index)
-      constructor_spec = @spec['constructors'][index]
-      wrapped_function = constructor_spec['wrapped-function']
-
-      yield "#{@spec['name']}::#{wrapped_constructor_signature(index)}{"
-
-      result = resolve_param wrapped_function['return']['type']
-
-      yield "  #{result} = #{function_call wrapped_function};"
-
-      yield '}'
     end
 
     # The definition of the member constructor for a class. This is only valid
@@ -337,10 +314,6 @@ module Wrapture
         yield "    #{struct_constructor_signature};"
         yield "    #{pointer_constructor_signature};"
       end
-
-      #@spec['constructors'].each_index do |constructor|
-      #  yield "    #{wrapped_constructor_signature constructor};"
-      #end
 
       yield "    #{destructor_signature};" if @spec.key? 'destructor'
 
@@ -415,13 +388,6 @@ module Wrapture
 
         yield '  }'
       end
-
-      #@spec['constructors'].each_index do |constructor|
-      #  yield
-      #  wrapped_constructor_definition(constructor) do |line|
-      #    yield "  #{line}"
-      #  end
-      #end
 
       if @spec.key? 'destructor'
         yield

--- a/lib/wrapture/class_spec.rb
+++ b/lib/wrapture/class_spec.rb
@@ -64,6 +64,13 @@ module Wrapture
         @functions << FunctionSpec.new(function_spec, self, constructor: true)
       end
 
+      if @spec.key?('destructor')
+        function_spec = @spec['destructor'].dup
+        function_spec['name'] = "~#{@spec['name']}"
+
+        @functions << FunctionSpec.new(function_spec, self, destructor: true)
+      end
+
       @spec['functions'].each do |function_spec|
         @functions << FunctionSpec.new(function_spec, self)
       end

--- a/lib/wrapture/class_spec.rb
+++ b/lib/wrapture/class_spec.rb
@@ -51,13 +51,22 @@ module Wrapture
     # functions:: a list of function specs
     # constants:: a list of constant specs
     def initialize(spec, scope: Scope.new)
-      @spec = ClassSpec.normalize_spec_hash spec
+      @spec = ClassSpec.normalize_spec_hash(spec)
 
       @struct = StructSpec.new @spec['equivalent-struct']
 
       @functions = []
       @spec['functions'].each do |function_spec|
         @functions << FunctionSpec.new(function_spec, self)
+      end
+
+      @spec['constructors'].each do |constructor_spec|
+        function_spec = constructor_spec.dup
+
+        function_spec['name'] = @spec['name']
+        function_spec['params'] = constructor_spec['params']
+
+        @functions << FunctionSpec.new(function_spec, self, constructor: true)
       end
 
       @constants = []

--- a/lib/wrapture/constants.rb
+++ b/lib/wrapture/constants.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Wrapture
+  # A string denoting an equivalent struct type or value.
+  EQUIVALENT_STRUCT_KEYWORD = 'equivalent-struct'
+
+  # A string denoting a pointer to an equivalent struct type or value.
+  EQUIVALENT_POINTER_KEYWORD = 'equivalent-struct-pointer'
+end

--- a/lib/wrapture/function_spec.rb
+++ b/lib/wrapture/function_spec.rb
@@ -90,7 +90,7 @@ module Wrapture
     #
     # The following keys are optional:
     # static:: set to true if this is a static function.
-    def initialize(spec, owner = Scope.new)
+    def initialize(spec, owner = Scope.new, constructor: false)
       @owner = owner
       @spec = FunctionSpec.normalize_spec_hash(spec)
     end
@@ -156,6 +156,16 @@ module Wrapture
       end
 
       "#{@spec['wrapped-function']['name']}( #{resolved_params.join(', ')} )"
+    end
+
+    def resolve_type(type)
+      if type == 'equivalent-struct'
+        "struct #{@owner.struct_name}"
+      elsif type == 'equivalent-struct-pointer'
+        "struct #{@owner.struct_name} *"
+      else
+        type
+      end
     end
 
     def resolve_wrapped_param(param_spec)

--- a/lib/wrapture/function_spec.rb
+++ b/lib/wrapture/function_spec.rb
@@ -112,7 +112,17 @@ module Wrapture
 
     # The signature of the function.
     def signature
-      "#{@spec['name']}( #{FunctionSpec.param_list @spec} )"
+      params = []
+
+      @spec['params'].each do |param|
+        params << ClassSpec.typed_variable(resolve_type(param['type']), param['name'])
+      end
+
+      if @spec['params'].empty?
+        "#{@spec['name']}( void )"
+      else
+        "#{@spec['name']}( #{params.join(', ')} )"
+      end
     end
 
     # The declaration of the function.
@@ -158,10 +168,11 @@ module Wrapture
       "#{@spec['wrapped-function']['name']}( #{resolved_params.join(', ')} )"
     end
 
+    # A resolved type name.
     def resolve_type(type)
-      if type == 'equivalent-struct'
+      if type == EQUIVALENT_STRUCT_KEYWORD
         "struct #{@owner.struct_name}"
-      elsif type == 'equivalent-struct-pointer'
+      elsif type == EQUIVALENT_POINTER_KEYWORD
         "struct #{@owner.struct_name} *"
       else
         type

--- a/lib/wrapture/function_spec.rb
+++ b/lib/wrapture/function_spec.rb
@@ -76,9 +76,10 @@ module Wrapture
     #
     # The following keys are optional:
     # static:: set to true if this is a static function.
-    def initialize(spec, owner = Scope.new, constructor: false)
+    def initialize(spec, owner = Scope.new, constructor: false, destructor: false)
       @owner = owner
       @spec = FunctionSpec.normalize_spec_hash(spec)
+      @structor = constructor || destructor
     end
 
     # A list of includes needed for the declaration of the function.
@@ -113,6 +114,8 @@ module Wrapture
 
     # The declaration of the function.
     def declaration
+      return signature if @structor
+
       modifier_prefix = @spec['static'] ? 'static ' : ''
       "#{modifier_prefix}#{@spec['return']['type']} #{signature}"
     end
@@ -120,7 +123,8 @@ module Wrapture
     # Gives the definition of the function to a block, line by line.
     def definition(class_name)
       return_type = @spec['return']['type']
-      yield "#{return_type} #{class_name}::#{signature} {"
+      return_prefix = @structor ? '' : "#{return_type} "
+      yield "#{return_prefix}#{class_name}::#{signature} {"
 
       wrapped_call = String.new
       wrapped_call << "return #{return_type} ( " unless return_type == 'void'

--- a/lib/wrapture/function_spec.rb
+++ b/lib/wrapture/function_spec.rb
@@ -62,20 +62,6 @@ module Wrapture
       normalized
     end
 
-    # A comma-separated string of each parameter with its type, suitable for use
-    # in function signatures and definitions.
-    def self.param_list(spec)
-      return 'void' if spec['params'].empty?
-
-      params = []
-
-      spec['params'].each do |param|
-        params << ClassSpec.typed_variable(param['type'], param['name'])
-      end
-
-      params.join ', '
-    end
-
     # Creates a function spec based on the provided function spec.
     #
     # The hash must have the following keys:

--- a/lib/wrapture/function_spec.rb
+++ b/lib/wrapture/function_spec.rb
@@ -102,6 +102,7 @@ module Wrapture
     # function signature or declaration.
     def param_list
       return 'void' if @spec['params'].empty?
+
       params = []
 
       @spec['params'].each do |param|

--- a/lib/wrapture/function_spec.rb
+++ b/lib/wrapture/function_spec.rb
@@ -98,8 +98,10 @@ module Wrapture
       includes.uniq
     end
 
-    # The signature of the function.
-    def signature
+    # A comma-separated list of parameters and resolved types fit for use in a
+    # function signature or declaration.
+    def param_list
+      return 'void' if @spec['params'].empty?
       params = []
 
       @spec['params'].each do |param|
@@ -107,11 +109,12 @@ module Wrapture
         params << ClassSpec.typed_variable(type, param['name'])
       end
 
-      if @spec['params'].empty?
-        "#{@spec['name']}( void )"
-      else
-        "#{@spec['name']}( #{params.join(', ')} )"
-      end
+      params.join(', ')
+    end
+
+    # The signature of the function.
+    def signature
+      "#{@spec['name']}( #{param_list} )"
     end
 
     # The declaration of the function.

--- a/lib/wrapture/function_spec.rb
+++ b/lib/wrapture/function_spec.rb
@@ -76,7 +76,8 @@ module Wrapture
     #
     # The following keys are optional:
     # static:: set to true if this is a static function.
-    def initialize(spec, owner = Scope.new, constructor: false, destructor: false)
+    def initialize(spec, owner = Scope.new, constructor: false,
+                   destructor: false)
       @owner = owner
       @spec = FunctionSpec.normalize_spec_hash(spec)
       @structor = constructor || destructor
@@ -102,7 +103,8 @@ module Wrapture
       params = []
 
       @spec['params'].each do |param|
-        params << ClassSpec.typed_variable(resolve_type(param['type']), param['name'])
+        type = resolve_type(param['type'])
+        params << ClassSpec.typed_variable(type, param['name'])
       end
 
       if @spec['params'].empty?

--- a/test/test_class_spec.rb
+++ b/test/test_class_spec.rb
@@ -47,8 +47,8 @@ class ClassSpecTest < Minitest::Test
     wrapped_function = test_spec['constructors'][0]['wrapped-function']
     assert_includes(includes, wrapped_function['includes'])
 
-    forbiden = Wrapture::EQUIVALENT_STRUCT_KEYWORD
-    assert(!file_contains_match(source_file, forbiden))
+    forbidden = Wrapture::EQUIVALENT_STRUCT_KEYWORD
+    assert(!file_contains_match(source_file, forbidden))
 
     File.delete(*classes)
   end

--- a/test/test_class_spec.rb
+++ b/test/test_class_spec.rb
@@ -43,7 +43,7 @@ class ClassSpecTest < Minitest::Test
     validate_wrapper_results(test_spec, classes)
 
     includes = get_include_list("#{test_spec['name']}.cpp")
-    assert_includes(includes, test_spec['constructors'][0]['includes'])
+    assert_includes(includes, test_spec['constructors'][0]['wrapped-function']['includes'])
 
     File.delete(*classes)
   end

--- a/test/test_class_spec.rb
+++ b/test/test_class_spec.rb
@@ -43,7 +43,8 @@ class ClassSpecTest < Minitest::Test
     validate_wrapper_results(test_spec, classes)
 
     includes = get_include_list("#{test_spec['name']}.cpp")
-    assert_includes(includes, test_spec['constructors'][0]['wrapped-function']['includes'])
+    wrapped_function = test_spec['constructors'][0]['wrapped-function']
+    assert_includes(includes, wrapped_function['includes'])
 
     File.delete(*classes)
   end

--- a/test/test_class_spec.rb
+++ b/test/test_class_spec.rb
@@ -37,10 +37,13 @@ class ClassSpecTest < Minitest::Test
   def test_class_with_constructor
     test_spec = load_fixture('constructor_class')
 
-    spec = Wrapture::ClassSpec.new test_spec
+    spec = Wrapture::ClassSpec.new(test_spec)
 
     classes = spec.generate_wrappers
     validate_wrapper_results(test_spec, classes)
+
+    includes = get_include_list("#{test_spec['name']}.cpp")
+    assert_includes(includes, test_spec['constructors'][0]['includes'])
 
     File.delete(*classes)
   end

--- a/test/test_class_spec.rb
+++ b/test/test_class_spec.rb
@@ -42,9 +42,13 @@ class ClassSpecTest < Minitest::Test
     classes = spec.generate_wrappers
     validate_wrapper_results(test_spec, classes)
 
-    includes = get_include_list("#{test_spec['name']}.cpp")
+    source_file = "#{test_spec['name']}.cpp"
+    includes = get_include_list(source_file)
     wrapped_function = test_spec['constructors'][0]['wrapped-function']
     assert_includes(includes, wrapped_function['includes'])
+
+    forbiden = Wrapture::EQUIVALENT_STRUCT_KEYWORD
+    assert(!file_contains_match(source_file, forbiden))
 
     File.delete(*classes)
   end


### PR DESCRIPTION
Constructors and destructors were being generated using a separate set of functionality, which overlapped with the standard function wrapping code in many cases. This change refactors the code generation for these special functions to use the standard wrapping code, simplifying the logic flow and removing duplicate code.

Automatically generated constructors based on struct members are still handled via their own set of functions. These should be refactored to use the standard functionality as well in the future, but this will require some extra functionality for generating wrappers that is not currently present.