### PR TITLE
allow classes to specify parents

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Python class generation.
  - Perl class generation.
 
-## [0.3.0] - 2019-09-02
+## [0.3.0] - 2019-09-22
 ### Added
  - Examples of basic usage and features.
  - Option to give a class-level include list.
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - `includes` property for function parameters.
  - `bin/wapture` now accepts multiple input files.
  - `version` field in specs for explicit support checks.
+ - Classes may have a parent class specified.
 
 ### Fixed
  - `bin/wrapture` is now executable.

--- a/docs/examples/inheritance/.gitignore
+++ b/docs/examples/inheritance/.gitignore
@@ -1,0 +1,2 @@
+MylibError.cpp
+MylibError.hpp

--- a/docs/examples/inheritance/README.md
+++ b/docs/examples/inheritance/README.md
@@ -1,0 +1,63 @@
+# Inheritance with Wrapture
+
+Of course there will come a time when you want to create a class that is a
+child of some other class. Wrapture makes this extremely straightforward: all
+that you need to do is specify the name of the class you wish to inherit from,
+and of course any headers that must be included to make this valid.
+
+The most common example of this scenario is wrapping some custom error handling
+code into an exception in the target language. Let's consider a simple example
+where we want to create an exception wrapper for an error code in our library.
+
+```c
+struct mylib_error {
+  int code;
+  const char *message;
+};
+```
+
+Wrapping this simple error struct is straightforward, and we simply add a
+`parent` field specifying the class to inherit from:
+
+```yaml
+classes:
+  - name: "MylibError"
+    namespace: "mylib"
+    equivalent-struct:
+      name: "mylib_error"
+    parent:
+      name: "std::exception"
+      includes: "exception"
+```
+
+We will also add a constructor for the class so that it can be thrown without
+any additional arguments:
+
+```yaml
+    constructors:
+      - wrapped-function:
+          name: "raise_mylib_error"
+          includes: "mylib.h"
+          return:
+            type: "equivalent-struct-pointer"
+```
+
+The result of this spec is a class that inherits from the standard library's
+exception class and is also a wrapping of the wrapped library's error struct.
+You can then throw this exception like you would any native exception:
+
+```cpp
+void i_will_fail( void ) {
+  throw MylibError();
+}
+```
+
+If you want to run this example, all that remains after using wrapture to
+generate the sources is to compile them and run the `error_usage` program to see
+the output:
+
+```sh
+# assuming that you're using sh and have g++
+g++ -I . mylib.c MylibError.cpp error_usage.cpp -o error_usage_example
+./error_usage_example
+```

--- a/docs/examples/inheritance/error.yml
+++ b/docs/examples/inheritance/error.yml
@@ -1,0 +1,15 @@
+classes:
+  - name: "MylibError"
+    namespace: "mylib"
+    equivalent-struct:
+      name: "mylib_error"
+      includes: "mylib.h"
+    parent:
+      name: "std::exception"
+      includes: "exception"
+    constructors:
+      - wrapped-function:
+          name: "raise_mylib_error"
+          includes: "mylib.h"
+          return:
+            type: "equivalent-struct-pointer"

--- a/docs/examples/inheritance/error_usage.cpp
+++ b/docs/examples/inheritance/error_usage.cpp
@@ -1,0 +1,20 @@
+#include <cstdlib>
+#include <iostream>
+#include <MylibError.hpp>
+
+using namespace std;
+using namespace mylib;
+
+void i_will_fail( void ) {
+  throw MylibError();
+}
+
+int main( int argc, char **argv ) {
+  try {
+    i_will_fail();
+  } catch( MylibError err ) {
+    cout << "caught a MylibError with message: " << err.equivalent->message << endl;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/docs/examples/inheritance/error_usage.cpp
+++ b/docs/examples/inheritance/error_usage.cpp
@@ -2,13 +2,13 @@
 
 /*
  * Copyright 2019 Joel E. Anderson
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/docs/examples/inheritance/error_usage.cpp
+++ b/docs/examples/inheritance/error_usage.cpp
@@ -1,3 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * Copyright 2019 Joel E. Anderson
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include <cstdlib>
 #include <iostream>
 #include <MylibError.hpp>

--- a/docs/examples/inheritance/mylib.c
+++ b/docs/examples/inheritance/mylib.c
@@ -1,3 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * Copyright 2019 Joel E. Anderson
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include <mylib.h>
 #include <stddef.h>
 #include <stdlib.h>

--- a/docs/examples/inheritance/mylib.c
+++ b/docs/examples/inheritance/mylib.c
@@ -2,13 +2,13 @@
 
 /*
  * Copyright 2019 Joel E. Anderson
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/docs/examples/inheritance/mylib.c
+++ b/docs/examples/inheritance/mylib.c
@@ -1,0 +1,18 @@
+#include <mylib.h>
+#include <stddef.h>
+#include <stdlib.h>
+
+struct mylib_error *
+raise_mylib_error( void ) {
+  struct mylib_error *err;
+
+  err = ( struct mylib_error * ) malloc( sizeof( *err ) );
+  if( !err ) {
+    return NULL;
+  }
+
+  err->code = 3;
+  err->message = "ya done messed up, A-A-Ron!!!";
+
+  return err;
+}

--- a/docs/examples/inheritance/mylib.h
+++ b/docs/examples/inheritance/mylib.h
@@ -1,3 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * Copyright 2019 Joel E. Anderson
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #ifndef __MYLIB_H
 #define __MYLIB_H
 

--- a/docs/examples/inheritance/mylib.h
+++ b/docs/examples/inheritance/mylib.h
@@ -2,13 +2,13 @@
 
 /*
  * Copyright 2019 Joel E. Anderson
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/docs/examples/inheritance/mylib.h
+++ b/docs/examples/inheritance/mylib.h
@@ -1,0 +1,12 @@
+#ifndef __MYLIB_H
+#define __MYLIB_H
+
+struct mylib_error {
+  int code;
+  const char *message;
+};
+
+struct mylib_error *
+raise_mylib_error( void );
+
+#endif

--- a/docs/examples/inheritance/mylib_error.yml
+++ b/docs/examples/inheritance/mylib_error.yml
@@ -1,0 +1,7 @@
+classes:
+  - name: "MyLibraryError"
+    namespace: "mylib"
+    equivalent-struct:
+      name: "mylib_error"
+    parent:
+      name: "exception"

--- a/test/fixtures/child_class.yml
+++ b/test/fixtures/child_class.yml
@@ -1,0 +1,7 @@
+name: "ChildClass"
+namespace: "wrapture_test"
+equivalent-struct:
+  name: "error_struct"
+parent:
+  name: "exception"
+  includes: "exception"

--- a/test/test_class_spec.rb
+++ b/test/test_class_spec.rb
@@ -34,6 +34,17 @@ class ClassSpecTest < Minitest::Test
     File.delete(*classes)
   end
 
+  def test_child_class
+    test_spec = load_fixture('child_class')
+
+    spec = Wrapture::ClassSpec.new(test_spec)
+
+    classes = spec.generate_wrappers
+    validate_wrapper_results(test_spec, classes)
+
+    File.delete(*classes)
+  end
+
   def test_class_with_constructor
     test_spec = load_fixture('constructor_class')
 


### PR DESCRIPTION
Allow the specification of a parent class, This allows generated classes to inherit from standard classes or others. For example, this could be used for the creation of custom exception, or extending other standard library classes.