### PR TITLE
add default member value support

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Python class generation.
  - Perl class generation.
 
-## [0.3.0] - 2019-11-01
+## [0.3.0] - 2019-11-02
 ### Added
  - Examples of basic usage and features.
  - Option to give a class-level include list.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Python class generation.
  - Perl class generation.
 
-## [0.3.0] - 2019-09-22
+## [0.3.0] - 2019-11-01
 ### Added
  - Examples of basic usage and features.
  - Option to give a class-level include list.
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - `bin/wapture` now accepts multiple input files.
  - `version` field in specs for explicit support checks.
  - Classes may have a parent class specified.
+ - Struct members may have default values specified to allow for the generation
+   of a default constructor.
 
 ### Fixed
  - `bin/wrapture` is now executable.

--- a/docs/examples/struct_wrapper/README.md
+++ b/docs/examples/struct_wrapper/README.md
@@ -43,9 +43,9 @@ There will also be two other constructors which accept either a struct, or a
 struct pointer, and copy all members to the class instantiation.
 
 This is all that's required to generate the basic struct wrapping. However, if
-you'd like a default constructor to be generated that doesn't require any
-parameters, then you'll need to give some extra information. For each member,
-just define a default value. Then the members section would look like this:
+you'd like a default constructor that doesn't require any parameters, then
+you'll need to provide a little more information. For each member, just define
+a default value. This would look like this:
 
 ```yaml
       members:
@@ -60,8 +60,10 @@ just define a default value. Then the members section would look like this:
           default-value: 0
 ```
 
-This will make it much easier to extend this class as well, as it provides a
-default constructor that can be called to initialize a child class.
+Now it will be much easier to extend this class, as it provides a default
+constructor that can be called to initialize a child class. If you only provide
+a few default values but not all of them, those will be optional in the
+constructor.
 
 Adding a function to our PlayerStats class is the same as with any other
 Wrapture class. For example, if we have a simple print function for the stats:

--- a/docs/examples/struct_wrapper/README.md
+++ b/docs/examples/struct_wrapper/README.md
@@ -42,6 +42,27 @@ constructor with three parameters, each corresponding to the listed members.
 There will also be two other constructors which accept either a struct, or a
 struct pointer, and copy all members to the class instantiation.
 
+This is all that's required to generate the basic struct wrapping. However, if
+you'd like a default constructor to be generated that doesn't require any
+parameters, then you'll need to give some extra information. For each member,
+just define a default value. Then the members section would look like this:
+
+```yaml
+      members:
+        - name: "goals_scored"
+          type: "int"
+          default-value: 0
+        - name: "yellow_cards"
+          type: "int"
+          default-value: 0
+        - name: "red_cards"
+          type: "int"
+          default-value: 0
+```
+
+This will make it much easier to extend this class as well, as it provides a
+default constructor that can be called to initialize a child class.
+
 Adding a function to our PlayerStats class is the same as with any other
 Wrapture class. For example, if we have a simple print function for the stats:
 
@@ -89,4 +110,12 @@ program to see the output:
 # assuming that you're using sh and have g++
 g++ -I . stats.c PlayerStats.cpp stats_usage.cpp -o stats_usage_example
 ./stats_usage_example
+
+# output:
+# default player's stats:
+#   player scored 0 goals, earned 0 yellow cards, and 0 red cards
+# my player's stats:
+#   player scored 3 goals, earned 5 yellow cards, and 1 red cards
+# their player's stats:
+#   player scored 0 goals, earned 4 yellow cards, and 4 red cards
 ```

--- a/docs/examples/struct_wrapper/stats.c
+++ b/docs/examples/struct_wrapper/stats.c
@@ -3,8 +3,7 @@
 
 void
 print_player_stats( struct player_stats *stats ) {
-  printf( "this player has scored %d goals and has earned %d yellow cards "
-          "and %d red cards\n",
+  printf( "player scored %d goals, earned %d yellow cards, and %d red cards\n",
           stats->goals_scored,
           stats->yellow_cards,
           stats->red_cards );

--- a/docs/examples/struct_wrapper/stats.yml
+++ b/docs/examples/struct_wrapper/stats.yml
@@ -7,10 +7,16 @@ classes:
       members:
         - name: "goals_scored"
           type: "int"
+          # games start with no goals scored
+          default-value: 0
         - name: "yellow_cards"
           type: "int"
+          # players start without any yellow cards
+          default-value: 0
         - name: "red_cards"
           type: "int"
+          # players start without any red cards
+          default-value: 0
     functions:
       - name: "Print"
         wrapped-function:

--- a/docs/examples/struct_wrapper/stats_usage.cpp
+++ b/docs/examples/struct_wrapper/stats_usage.cpp
@@ -6,13 +6,17 @@ using namespace std;
 using namespace soccer;
 
 int main( int argc, char **argv ) {
+  PlayerStats default_player;
   PlayerStats my_player ( 3, 5, 1 );
   PlayerStats their_player (0, 4, 4 );
 
-  cout << "my player's stats: ";
+  cout << "default player's stats:\n  ";
+  default_player.Print();
+
+  cout << "my player's stats:\n  ";
   my_player.Print();
 
-  cout << "their player's stats: ";
+  cout << "their player's stats:\n  ";
   their_player.Print();
 
   return EXIT_SUCCESS;

--- a/lib/wrapture/class_spec.rb
+++ b/lib/wrapture/class_spec.rb
@@ -243,24 +243,24 @@ module Wrapture
     # Yields the declaration of the member constructor for a class. This will be
     # empty if the wrapped struct is a pointer wrapper.
     def member_constructor_declaration
-      if @struct.members?
-        yield "#{@spec['name']}( #{@struct.member_list_with_defaults} );"
-      end
+      return unless @struct.members?
+
+      yield "#{@spec['name']}( #{@struct.member_list_with_defaults} );"
     end
 
     # Yields the definition of the member constructor for a class. This will be
     # empty if the wrapped struct is a pointer wrapper.
     def member_constructor_definition
-      if @struct.members?
-        yield "#{@spec['name']}::#{@spec['name']}( #{@struct.member_list} ) {"
+      return unless @struct.members?
 
-        @struct.members.each do |member|
-          member_decl = this_member(member['name'])
-          yield "  #{member_decl} = #{member['name']};"
-        end
+      yield "#{@spec['name']}::#{@spec['name']}( #{@struct.member_list} ) {"
 
-        yield '}'
+      @struct.members.each do |member|
+        member_decl = this_member(member['name'])
+        yield "  #{member_decl} = #{member['name']};"
       end
+
+      yield '}'
     end
 
     # The signature of the constructor given an equivalent struct type.

--- a/lib/wrapture/struct_spec.rb
+++ b/lib/wrapture/struct_spec.rb
@@ -59,13 +59,15 @@ module Wrapture
         member_str = ClassSpec.typed_variable(member['type'], member['name'])
 
         if member.key?('default-value')
+          default_value = member['default-value']
+
           member_str += ' = '
           member_str += if member['type'] == 'const char *'
-                          '"' + member['default-value'] + '"'
+                          '"' + default_value + '"'
                         elsif member['type'].end_with?('char')
-                          "'" + member['default-value'] + "'"
+                          "'#{default_value}'"
                         else
-                          member['default-value'].to_s
+                          default_value.to_s
                         end
         end
 

--- a/lib/wrapture/struct_spec.rb
+++ b/lib/wrapture/struct_spec.rb
@@ -52,6 +52,27 @@ module Wrapture
       members.join ', '
     end
 
+    # A string containing the typed members of the struct, with their default
+    # values if provided, separated by commas.
+    def member_list_with_defaults
+      @spec['members'].map do |member|
+        member_str = ClassSpec.typed_variable(member['type'], member['name'])
+
+        if member.key?('default-value')
+          member_str += ' = '
+          member_str += if member['type'] == 'const char *'
+                          '"' + member['default-value'] + '"'
+                        elsif member['type'].end_with?('char')
+                          "'" + member['default-value'] + "'"
+                        else
+                          member['default-value'].to_s
+                        end
+        end
+
+        member_str
+      end.join(', ')
+    end
+
     # The members of the struct
     def members
       @spec['members']

--- a/test/fixtures/default_value_members.yml
+++ b/test/fixtures/default_value_members.yml
@@ -1,0 +1,30 @@
+name: "DefaultMembersClass"
+namespace: "wrapture_test"
+equivalent-struct:
+  name: "struct_to_wrap"
+  includes:
+    - "struct_header.h"
+    - "another_struct_header.h"
+  # If all members of a struct with members given have default values, then a
+  # default constructor will be available for the class using these.
+  members:
+    - name: "member_1"
+      type: "int"
+      # a member may have a default value, which will be used in constructors
+      # to make the member optional.
+      default-value: 42
+    - name: "member_2"
+      type: "const char *"
+      # String defaults are okay too.
+      default-value: "fidelio"
+    - name: "member_3"
+      type: "unsigned char"
+      default-value: "t"
+functions:
+  - name: "WrappedFunction"
+    return:
+      type: "DefaultMembersClass"
+    wrapped-function:
+      name: "native_function"
+      params:
+        - name: "equivalent-struct"

--- a/test/test_class_spec.rb
+++ b/test/test_class_spec.rb
@@ -94,6 +94,18 @@ class ClassSpecTest < Minitest::Test
     File.delete(*classes)
   end
 
+  def test_default_constructor_generation
+    test_spec = load_fixture('default_value_members')
+
+    spec = Wrapture::ClassSpec.new(test_spec)
+
+    classes = spec.generate_wrappers
+    validate_wrapper_results(test_spec, classes)
+    assert(file_contains_match("DefaultMembersClass.hpp", "member_1 = 42"))
+
+    File.delete(*classes)
+  end
+
   def test_versioned_class
     test_spec = load_fixture('versioned_class')
 

--- a/test/test_class_spec.rb
+++ b/test/test_class_spec.rb
@@ -101,7 +101,7 @@ class ClassSpecTest < Minitest::Test
 
     classes = spec.generate_wrappers
     validate_wrapper_results(test_spec, classes)
-    assert(file_contains_match("DefaultMembersClass.hpp", "member_1 = 42"))
+    assert(file_contains_match('DefaultMembersClass.hpp', 'member_1 = 42'))
 
     File.delete(*classes)
   end


### PR DESCRIPTION
Members of structs can have a default value specified with the optional default-value key.

This also allows inheritance to be easier with struct wrapping classes, as it allows a default constructor to be generated that can be called in child class constructors.