### PR TITLE
support virtual functions

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Python class generation.
  - Perl class generation.
 
-## [0.3.0] - 2019-11-02
+## [0.3.0] - 2019-11-16
 ### Added
  - Examples of basic usage and features.
  - Option to give a class-level include list.
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Classes may have a parent class specified.
  - Struct members may have default values specified to allow for the generation
    of a default constructor.
+ - Support for virtual functions.
 
 ### Fixed
  - `bin/wrapture` is now executable.

--- a/docs/examples/basic/README.md
+++ b/docs/examples/basic/README.md
@@ -153,7 +153,7 @@ We can define the remaining two functions in the same way:
 
 Static and virtual functions are defined in the same manner, but with one
 additional field named `static` or `virtual` (respectively) set to true. For
-this case, we'll define a `static` function:
+this example we'll define a `static` function:
 
 ```yaml
       - name: "IsModelSupported"

--- a/docs/examples/basic/README.md
+++ b/docs/examples/basic/README.md
@@ -151,8 +151,9 @@ We can define the remaining two functions in the same way:
             - name: "new_level"
 ```
 
-Static functions are defined in the same manner, but with one additional field
-named `static` set to true.
+Static and virtual functions are defined in the same manner, but with one
+additional field named `static` or `virtual` (respectively) set to true. For
+this case, we'll define a `static` function:
 
 ```yaml
       - name: "IsModelSupported"

--- a/lib/wrapture/errors.rb
+++ b/lib/wrapture/errors.rb
@@ -1,4 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+
 # frozen_string_literal: true
+
+# Copyright 2019 Joel E. Anderson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 module Wrapture
   # An error from the Wrapture library

--- a/lib/wrapture/errors.rb
+++ b/lib/wrapture/errors.rb
@@ -5,6 +5,14 @@ module Wrapture
   class WraptureError < StandardError
   end
 
+  # The spec has a key that is not valid.
+  class InvalidSpecKey < WraptureError
+    # Creates an InvalidSpecKey with the given message.
+    def initialize(message)
+      super(message)
+    end
+  end
+
   # Missing a namespace in the class spec
   class NoNamespace < WraptureError
   end

--- a/lib/wrapture/function_spec.rb
+++ b/lib/wrapture/function_spec.rb
@@ -125,7 +125,7 @@ module Wrapture
       modifier_prefix = if @spec['static']
                           'static '
                         elsif virtual?
-                          'virtual'
+                          'virtual '
                         else
                           ''
                         end

--- a/lib/wrapture/function_spec.rb
+++ b/lib/wrapture/function_spec.rb
@@ -122,7 +122,13 @@ module Wrapture
     def declaration
       return signature if @constructor || @destructor
 
-      modifier_prefix = @spec['static'] ? 'static ' : ''
+      modifier_prefix = if @spec['static']
+                          'static '
+                        elsif virtual?
+                          'virtual'
+                        else
+                          ''
+                        end
       "#{modifier_prefix}#{@spec['return']['type']} #{signature}"
     end
 

--- a/lib/wrapture/function_spec.rb
+++ b/lib/wrapture/function_spec.rb
@@ -1,4 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+
 # frozen_string_literal: true
+
+# Copyright 2019 Joel E. Anderson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 require 'wrapture/constants'
 require 'wrapture/errors'

--- a/lib/wrapture/function_spec.rb
+++ b/lib/wrapture/function_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'wrapture/constants'
+require 'wrapture/errors'
 require 'wrapture/scope'
 require 'wrapture/wrapped_function_spec'
 
@@ -17,6 +18,7 @@ module Wrapture
       param_types = {}
 
       normalized['version'] = Wrapture.spec_version(spec)
+      normalized['virtual'] = Wrapture.normalize_boolean(spec, 'virtual')
 
       normalized['params'] ||= []
       normalized['params'].each do |param_spec|
@@ -143,6 +145,11 @@ module Wrapture
 
       yield "  #{wrapped_call};"
       yield '}'
+    end
+
+    # True if the function is virtual.
+    def virtual?
+      @spec['virtual']
     end
 
     private

--- a/lib/wrapture/normalize.rb
+++ b/lib/wrapture/normalize.rb
@@ -1,4 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+
 # frozen_string_literal: true
+
+# Copyright 2019 Joel E. Anderson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 require 'wrapture/version'
 

--- a/lib/wrapture/normalize.rb
+++ b/lib/wrapture/normalize.rb
@@ -3,6 +3,16 @@
 require 'wrapture/version'
 
 module Wrapture
+  # Normalizes a spec key to be boolean, raising an error if it is not. Keys
+  # that are not present are defaulted to false.
+  def self.normalize_boolean(spec, key)
+    is_boolean = [true, false].include?(spec[key])
+    error_msg = "'#{key}' key may only be true or false"
+    raise(InvalidSpecKey, error_msg) unless !spec.key?(key) || is_boolean
+
+    spec.key?(key) && spec[key]
+  end
+
   # Normalizes an include list for an element. A single string will be converted
   # into an array containing the single string, and a nil will be converted to
   # an empty array.

--- a/test/fixtures/class_with_virtual_function.yml
+++ b/test/fixtures/class_with_virtual_function.yml
@@ -1,0 +1,12 @@
+name: "BaseClass"
+namespace: "wrapture_test"
+equivalent-struct:
+  name: "overloaded_struct"
+  includes: "allthethings.h"
+functions:
+  - name: "VirtualFunction"
+    virtual: true
+    wrapped-function:
+      name: "vanilla_flavor"
+      params:
+        - value: "equivalent-struct-pointer"

--- a/test/fixtures/invalid/invalid_virtual_key.yml
+++ b/test/fixtures/invalid/invalid_virtual_key.yml
@@ -1,0 +1,6 @@
+name: "VirtualFunction"
+virtual: "yes, please"
+wrapped-function:
+  name: "underlying_function"
+  params:
+    - value: "equivalent-struct-pointer"

--- a/test/fixtures/virtual_function.yml
+++ b/test/fixtures/virtual_function.yml
@@ -1,0 +1,6 @@
+name: "VirtualFunction"
+virtual: true
+wrapped-function:
+  name: "underlying_function"
+  params:
+    - value: "equivalent-struct-pointer"

--- a/test/test_invalid.rb
+++ b/test/test_invalid.rb
@@ -6,6 +6,14 @@ require 'minitest/autorun'
 require 'wrapture'
 
 class InvalidTest < Minitest::Test
+  def test_invalid_virtual_key
+    test_spec = load_fixture('invalid/invalid_virtual_key')
+
+    assert_raises(Wrapture::InvalidSpecKey) do
+      Wrapture::FunctionSpec.new(test_spec)
+    end
+  end
+
   def test_no_namespace
     test_spec = load_fixture 'invalid/no_namespace'
 

--- a/test/test_invalid.rb
+++ b/test/test_invalid.rb
@@ -1,4 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+
 # frozen_string_literal: true
+
+# Copyright 2019 Joel E. Anderson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 require 'helper'
 

--- a/test/test_virtual_function.rb
+++ b/test/test_virtual_function.rb
@@ -1,4 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+
 # frozen_string_literal: true
+
+# Copyright 2019 Joel E. Anderson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 require 'helper'
 

--- a/test/test_virtual_function.rb
+++ b/test/test_virtual_function.rb
@@ -15,6 +15,8 @@ class FunctionSpecTest < Minitest::Test
     classes = spec.generate_wrappers
     validate_wrapper_results(test_spec, classes)
 
+    assert(file_contains_match('BaseClass.hpp', 'virtual'))
+
     File.delete(*classes)
   end
 

--- a/test/test_virtual_function.rb
+++ b/test/test_virtual_function.rb
@@ -15,7 +15,7 @@ class FunctionSpecTest < Minitest::Test
     classes = spec.generate_wrappers
     validate_wrapper_results(test_spec, classes)
 
-    assert(file_contains_match('BaseClass.hpp', 'virtual'))
+    assert(file_contains_match('BaseClass.hpp', 'virtual void'))
 
     File.delete(*classes)
   end

--- a/test/test_virtual_function.rb
+++ b/test/test_virtual_function.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'helper'
+
+require 'fixture'
+require 'minitest/autorun'
+require 'wrapture'
+
+class FunctionSpecTest < Minitest::Test
+  def test_class_with_virtual_function
+    test_spec = load_fixture('class_with_virtual_function')
+
+    spec = Wrapture::ClassSpec.new(test_spec)
+
+    classes = spec.generate_wrappers
+    validate_wrapper_results(test_spec, classes)
+
+    File.delete(*classes)
+  end
+
+  def test_virtual_function
+    test_spec = load_fixture('virtual_function')
+
+    func_spec = Wrapture::FunctionSpec.new(test_spec)
+    assert(func_spec.virtual?)
+  end
+end


### PR DESCRIPTION
Virtual functions are needed in classes that want to provide runtime polymorphism. Support for these functions is added by allowing a boolean flag to be set in the function specification.