### PR TITLE
default pointer wrapper constructor

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Python class generation.
  - Perl class generation.
 
-## [0.3.0] - 2019-11-17
+## [0.3.0] - 2019-11-18
 ### Added
  - Examples of basic usage and features.
  - Option to give a class-level include list.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Python class generation.
  - Perl class generation.
 
-## [0.3.0] - 2019-11-16
+## [0.3.0] - 2019-11-17
 ### Added
  - Examples of basic usage and features.
  - Option to give a class-level include list.
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Struct members may have default values specified to allow for the generation
    of a default constructor.
  - Support for virtual functions.
+ - Pointer wrapper classes are by default given a constructor that takes a
+   pointer to the equivalent struct and wraps it in the class.
 
 ### Fixed
  - `bin/wrapture` is now executable.

--- a/lib/wrapture/class_spec.rb
+++ b/lib/wrapture/class_spec.rb
@@ -1,4 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+
 # frozen_string_literal: true
+
+# Copyright 2019 Joel E. Anderson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 require 'wrapture/constant_spec'
 require 'wrapture/constants'
@@ -263,6 +279,40 @@ module Wrapture
       yield '}'
     end
 
+    # Yields the declaration of the pointer constructor for a class.
+    def pointer_constructor_declaration
+      yield "#{pointer_constructor_signature};"
+    end
+
+    # Yields the definition of the pointer constructor for a class.
+    #
+    # If there is already a constructor provided with this signature, then this
+    # function will return with no output.
+    #
+    # If this is a pointer wrapper class, then the constructor will simply set
+    # the underlying pointer to the provied one, and return the new object.
+    #
+    # If this is a struct wrapper class, then a constructor will be created that
+    # sets each member of the wrapped struct to the provided value.
+    def pointer_constructor_definition
+      return if @functions.any? do |func|
+        func.constructor? && func.signature == pointer_constructor_signature
+      end
+
+      yield "#{@spec['name']}::#{pointer_constructor_signature} {"
+
+      if pointer_wrapper?
+        yield '  this->equivalent = equivalent;'
+      else
+        @struct.members.each do |member|
+          member_decl = this_member(member['name'])
+          yield "  #{member_decl} = equivalent->#{member['name']};"
+        end
+      end
+
+      yield '}'
+    end
+
     # The signature of the constructor given an equivalent struct type.
     def struct_constructor_signature
       "#{@spec['name']}( #{@struct.declaration 'equivalent'} )"
@@ -320,10 +370,9 @@ module Wrapture
 
       member_constructor_declaration { |line| yield "    #{line}" }
 
-      unless pointer_wrapper?
-        yield "    #{struct_constructor_signature};"
-        yield "    #{pointer_constructor_signature};"
-      end
+      pointer_constructor_declaration { |line| yield "    #{line}" }
+
+      yield "    #{struct_constructor_signature};" unless pointer_wrapper?
 
       @functions.each do |func|
         yield "    #{func.declaration};"
@@ -364,6 +413,8 @@ module Wrapture
       end
 
       member_constructor_definition { |line| yield "  #{line}" }
+
+      pointer_constructor_definition { |line| yield "  #{line}" }
 
       unless pointer_wrapper?
         yield

--- a/lib/wrapture/class_spec.rb
+++ b/lib/wrapture/class_spec.rb
@@ -280,7 +280,15 @@ module Wrapture
     end
 
     # Yields the declaration of the pointer constructor for a class.
+    #
+    # If there is already a constructor provided with this signature, then this
+    # function will return with no output.
     def pointer_constructor_declaration
+      signature_prefix = "#{@spec['name']}( #{@struct.pointer_declaration('')}"
+      return if @functions.any? do |func|
+        func.constructor? && func.signature.start_with?(signature_prefix)
+      end
+
       yield "#{pointer_constructor_signature};"
     end
 
@@ -295,8 +303,9 @@ module Wrapture
     # If this is a struct wrapper class, then a constructor will be created that
     # sets each member of the wrapped struct to the provided value.
     def pointer_constructor_definition
+      signature_prefix = "#{@spec['name']}( #{@struct.pointer_declaration('')}"
       return if @functions.any? do |func|
-        func.constructor? && func.signature == pointer_constructor_signature
+        func.constructor? && func.signature.start_with?(signature_prefix)
       end
 
       yield "#{@spec['name']}::#{pointer_constructor_signature} {"

--- a/lib/wrapture/function_spec.rb
+++ b/lib/wrapture/function_spec.rb
@@ -75,8 +75,8 @@ module Wrapture
       @owner = owner
       @spec = FunctionSpec.normalize_spec_hash(spec)
       @wrapped = WrappedFunctionSpec.new(spec['wrapped-function'])
-      @constructor = !!constructor
-      @destructor = !!destructor
+      @constructor = constructor
+      @destructor = destructor
     end
 
     # True if the function is a constructor, false otherwise.

--- a/lib/wrapture/function_spec.rb
+++ b/lib/wrapture/function_spec.rb
@@ -75,8 +75,13 @@ module Wrapture
       @owner = owner
       @spec = FunctionSpec.normalize_spec_hash(spec)
       @wrapped = WrappedFunctionSpec.new(spec['wrapped-function'])
-      @constructor = constructor
-      @destructor = destructor
+      @constructor = !!constructor
+      @destructor = !!destructor
+    end
+
+    # True if the function is a constructor, false otherwise.
+    def constructor?
+      @constructor
     end
 
     # A list of includes needed for the declaration of the function.

--- a/test/fixtures/pointer_class.yml
+++ b/test/fixtures/pointer_class.yml
@@ -1,0 +1,19 @@
+name: "PointerWrappingClass"
+namespace: "wrapture_test"
+equivalent-struct:
+  name: "wrapped_struct"
+  includes: "wrapme.h"
+constructors:
+  - wrapped-function:
+      name: "new_thing"
+      params:
+        - name: "new_name"
+          type: "const char *"
+      return:
+        type: "equivalent-struct-pointer"
+destructor:
+  wrapped-function:
+    name: "destroy_a_struct"
+    params:
+      - name: "equivalent-struct-pointer"
+    includes: "wrapme.h"

--- a/test/test_pointer_class.rb
+++ b/test/test_pointer_class.rb
@@ -15,7 +15,7 @@ class ClassSpecTest < Minitest::Test
     classes = spec.generate_wrappers
     validate_wrapper_results(test_spec, classes)
 
-    expected_signature = 'PointerWrapperClass\( struct wrapped_struct \*'
+    expected_signature = 'PointerWrappingClass\( struct wrapped_struct \*'
     assert(file_contains_match('PointerWrappingClass.hpp', expected_signature))
 
     File.delete(*classes)

--- a/test/test_pointer_class.rb
+++ b/test/test_pointer_class.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'helper'
+
+require 'fixture'
+require 'minitest/autorun'
+require 'wrapture'
+
+class ClassSpecTest < Minitest::Test
+  def test_pointer_class
+    test_spec = load_fixture('pointer_class')
+
+    spec = Wrapture::ClassSpec.new(test_spec)
+
+    classes = spec.generate_wrappers
+    validate_wrapper_results(test_spec, classes)
+
+    expected_signature = 'PointerWrapperClass\( struct wrapped_struct \*'
+    assert(file_contains_match('PointerWrappingClass.hpp', expected_signature))
+
+    File.delete(*classes)
+  end
+end

--- a/test/test_pointer_class.rb
+++ b/test/test_pointer_class.rb
@@ -1,4 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+
 # frozen_string_literal: true
+
+# Copyright 2019 Joel E. Anderson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 require 'helper'
 
@@ -7,6 +23,24 @@ require 'minitest/autorun'
 require 'wrapture'
 
 class ClassSpecTest < Minitest::Test
+  def test_overriding_constructor
+    test_spec = load_fixture('constructor_class')
+
+    spec = Wrapture::ClassSpec.new(test_spec)
+
+    classes = spec.generate_wrappers
+    validate_wrapper_results(test_spec, classes)
+
+    count = 0
+    signature = 'ClassWithConstructor( struct constructed_struct *'
+    File.open('ClassWithConstructor.hpp').each do |line|
+      count += 1 if line.include?(signature)
+    end
+    assert_equal(1, count)
+
+    File.delete(*classes)
+  end
+
   def test_pointer_class
     test_spec = load_fixture('pointer_class')
 


### PR DESCRIPTION
Classes that wrap pointers should be able to create instances wrapped around a provided pointer. This capability is added along with some checks to ensure that it does not conflict with existing constructors or struct wrapping classes.