### PR TITLE
remove duplicate constructor definitions

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Python class generation.
  - Perl class generation.
 
-## [0.3.0] - 2019-11-19
+## [0.3.0] - 2019-11-27
 ### Added
  - Examples of basic usage and features.
  - Option to give a class-level include list.

--- a/lib/wrapture/class_spec.rb
+++ b/lib/wrapture/class_spec.rb
@@ -284,16 +284,6 @@ module Wrapture
         end
 
         yield '  }'
-
-        yield
-        yield "  #{@spec['name']}::#{pointer_constructor_signature} {"
-
-        @struct.members.each do |member|
-          member_decl = this_member(member['name'])
-          yield "    #{member_decl} = equivalent->#{member['name']};"
-        end
-
-        yield '  }'
       end
 
       overload_definition { |line| yield "  #{line}" }

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -34,7 +34,8 @@ require 'minitest/autorun'
 require 'wrapture'
 
 def count_matches(filename, regex)
-  count=0
+  count = 0
+
   File.open(filename).each do |line|
     count += 1 if line.match(regex)
   end
@@ -98,11 +99,13 @@ def validate_definition_file(spec)
     assert_includes(includes, class_include)
   end
 
-  def_count = count_matches(filename, "#{spec['name']}::#{spec['name']}\\( struct \\w+ \\*equivalent \\)")
+  sig = "#{spec['name']}::#{spec['name']}\\( struct \\w+ \\*equivalent \\)"
+  def_count = count_matches(filename, sig)
   assert(def_count <= 1)
 
   normalized['functions'].each do |func_spec|
-    def_count = count_matches(filename, "#{spec['name']}::#{func_spec['name']}\\(")
+    sig = "#{spec['name']}::#{func_spec['name']}\\("
+    def_count = count_matches(filename, sig)
     assert_equal(1, def_count, "not one definition of #{func_spec['name']}")
   end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -33,6 +33,15 @@ end
 require 'minitest/autorun'
 require 'wrapture'
 
+def count_matches(filename, regex)
+  count=0
+  File.open(filename).each do |line|
+    count += 1 if line.match(regex)
+  end
+
+  count
+end
+
 def file_contains_match(filename, regex)
   File.open(filename).each do |line|
     return true if line.match(regex)
@@ -80,12 +89,21 @@ end
 
 def validate_definition_file(spec)
   filename = "#{spec['name']}.cpp"
-  class_includes = Wrapture::ClassSpec.normalize_spec_hash(spec)['includes']
+  normalized = Wrapture::ClassSpec.normalize_spec_hash(spec)
+  class_includes = normalized['includes']
 
   includes = get_include_list filename
 
   class_includes.each do |class_include|
     assert_includes(includes, class_include)
+  end
+
+  def_count = count_matches(filename, "#{spec['name']}::#{spec['name']}\\( struct \\w+ \\*equivalent \\)")
+  assert(def_count <= 1)
+
+  normalized['functions'].each do |func_spec|
+    def_count = count_matches(filename, "#{spec['name']}::#{func_spec['name']}\\(")
+    assert_equal(1, def_count, "not one definition of #{func_spec['name']}")
   end
 
   validate_indentation filename


### PR DESCRIPTION
When the default pointer construction functionality was added, the old code to create the pointer constructors was not removed. This led to multiple definitions of a default constructor based on a pointer to the wrapped struct, which cases compilation issues. The duplicate code has been removed, and a test added to catch regressions.