### PR TITLE
update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ rvm:
 matrix:
   allow_failures:
     - os: osx
+      rvm: 2.3
+    - os: osx
       rvm: jruby
   include:
     - os: linux
@@ -49,7 +51,8 @@ matrix:
 
 before_install:
   - gem update --system --no-document
-  - if [[ $TRAVIS_RUBY_VERSION =~ "truffle" ]]; then gem install bundler -v 1.17.3 --no-document; else gem install bundler --no-document; fi
+#  - if [[ $TRAVIS_RUBY_VERSION =~ "truffle" ]]; then gem install bundler -v 1.17.3 --no-document; else gem install bundler --no-document; fi
+  - gem install bundler --no-document
 
 script:
   - if [[ $TRAVIS_RUBY_VERSION =~ "2.6" ]]; then bundle exec rubocop; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,6 @@ matrix:
 
 before_install:
   - gem update --system --no-document
-#  - if [[ $TRAVIS_RUBY_VERSION =~ "truffle" ]]; then gem install bundler -v 1.17.3 --no-document; else gem install bundler --no-document; fi
   - gem install bundler --no-document
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ matrix:
   allow_failures:
     - os: osx
       rvm: 2.3
-    - os: osx
-      rvm: jruby
   include:
     - os: linux
       dist: trusty

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'json', '>= 1.8', '<= 2.2'
+gem 'json', '>= 1.8', '<= 2.2' # needed for truffleruby to work
 
 group :development do
   gem 'rake', '>= 0.9.2'

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,8 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'json', '>= 1.8', '<= 2.2'
+
 group :development do
   gem 'rake', '>= 0.9.2'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,20 +8,20 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.0)
-    codecov (0.1.14)
+    codecov (0.1.16)
       json
       simplecov
       url
     docile (1.3.2)
-    jaro_winkler (1.5.2)
-    json (2.2.0)
-    minitest (5.11.3)
-    parallel (1.17.0)
-    parser (2.6.3.0)
+    jaro_winkler (1.5.4)
+    json (2.3.0)
+    minitest (5.13.0)
+    parallel (1.19.1)
+    parser (2.6.5.0)
       ast (~> 2.4.0)
     rainbow (3.0.0)
-    rake (12.3.2)
-    rubocop (0.71.0)
+    rake (13.0.1)
+    rubocop (0.78.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.6)
@@ -29,7 +29,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
     ruby-progressbar (1.10.1)
-    simplecov (0.16.1)
+    simplecov (0.17.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
@@ -49,4 +49,4 @@ DEPENDENCIES
   wrapture!
 
 BUNDLED WITH
-   1.17.3
+   2.1.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GEM
       url
     docile (1.3.2)
     jaro_winkler (1.5.4)
-    json (2.3.0)
+    json (2.2.0)
     minitest (5.13.0)
     parallel (1.19.1)
     parser (2.6.5.0)
@@ -42,6 +42,7 @@ PLATFORMS
 
 DEPENDENCIES
   codecov
+  json (>= 1.8, <= 2.2)
   minitest (>= 5.9)
   rake (>= 0.9.2)
   rubocop (>= 0.69)


### PR DESCRIPTION
There have been enough updates to dependency libraries that some of the CI tests have started to fail. This updates the versions and scripts specified to fix these issues.