### PR TITLE
allow explicit class type

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    pointer to the equivalent struct and wraps it in the class.
  - Structs can be wrapped by the best matching wrapper via the `newClassName`
    family of functions.
+ - Classes can be explicitly specified as pointer or struct wrapping classes
+   using the `type` property.
 
 ### Fixed
  - `bin/wrapture` is now executable.

--- a/lib/wrapture/class_spec.rb
+++ b/lib/wrapture/class_spec.rb
@@ -46,6 +46,14 @@ module Wrapture
         normalized['parent']['includes'] = includes
       end
 
+      if spec.key?('type')
+        valid_types = %w[pointer struct]
+        unless valid_types.include?(spec['type'])
+          type_message = "#{spec['type']} is not a valid class type"
+          raise InvalidSpecKey.new(type_message, valid_keys: valid_types)
+        end
+      end
+
       normalized
     end
 

--- a/lib/wrapture/class_spec.rb
+++ b/lib/wrapture/class_spec.rb
@@ -52,8 +52,8 @@ module Wrapture
 
     # Gives the effective type of the given class spec hash.
     def self.effective_type(spec)
-      inferred_pointer_wrapper = @spec['constructors'].any? do |spec|
-        spec['wrapped-function']['return']['type'] == EQUIVALENT_POINTER_KEYWORD
+      inferred_pointer_wrapper = spec['constructors'].any? do |func|
+        func['wrapped-function']['return']['type'] == EQUIVALENT_POINTER_KEYWORD
       end
 
       if spec.key?('type')

--- a/lib/wrapture/class_spec.rb
+++ b/lib/wrapture/class_spec.rb
@@ -46,12 +46,20 @@ module Wrapture
         normalized['parent']['includes'] = includes
       end
 
+      detected_pointer = normalized['constructors'].any? do |func|
+        func['wrapped-function']['return']['type'] == EQUIVALENT_POINTER_KEYWORD
+      end
+
       if spec.key?('type')
         valid_types = %w[pointer struct]
         unless valid_types.include?(spec['type'])
           type_message = "#{spec['type']} is not a valid class type"
           raise InvalidSpecKey.new(type_message, valid_keys: valid_types)
         end
+      elsif detected_pointer
+        normalized['type'] = 'pointer'
+      else
+        normalized['type'] = 'struct'
       end
 
       normalized
@@ -474,9 +482,7 @@ module Wrapture
 
     # Determines if this class is a wrapper for a struct pointer or not.
     def pointer_wrapper?
-      @spec['constructors'].any? do |spec|
-        spec['wrapped-function']['return']['type'] == EQUIVALENT_POINTER_KEYWORD
-      end
+      @spec['type'] == 'pointer'
     end
 
     # The signature of the constructor given an equivalent struct type.

--- a/lib/wrapture/errors.rb
+++ b/lib/wrapture/errors.rb
@@ -23,7 +23,9 @@ module Wrapture
 
   # The spec has a key that is not valid.
   class InvalidSpecKey < WraptureError
-    # Creates an InvalidSpecKey with the given message.
+    # Creates an InvalidSpecKey with the given message. A list of valid values
+    # may optionally be passed to +valid_keys+ which will be added to the end
+    # of the message.
     def initialize(message, valid_keys: [])
       complete_message = message.dup
 

--- a/lib/wrapture/errors.rb
+++ b/lib/wrapture/errors.rb
@@ -24,8 +24,16 @@ module Wrapture
   # The spec has a key that is not valid.
   class InvalidSpecKey < WraptureError
     # Creates an InvalidSpecKey with the given message.
-    def initialize(message)
-      super(message)
+    def initialize(message, valid_keys: [])
+      complete_message = message.dup
+
+      unless valid_keys.empty?
+        complete_message << ' (valid values are \''
+        complete_message << valid_keys.join('\', \'')
+        complete_message << '\')'
+      end
+
+      super(complete_message)
     end
   end
 

--- a/test/fixtures/explicit_pointer_class.yml
+++ b/test/fixtures/explicit_pointer_class.yml
@@ -1,0 +1,5 @@
+name: "ExplicitPointerWrapper"
+namespace: "wrapture_test"
+type: "pointer"
+equivalent-struct:
+  name: "basic_struct"

--- a/test/fixtures/invalid_type_class.yml
+++ b/test/fixtures/invalid_type_class.yml
@@ -1,0 +1,5 @@
+name: "ExplicitPointerWrapper"
+namespace: "wrapture_test"
+type: "tall"
+equivalent-struct:
+  name: "basic_struct"

--- a/test/test_class_spec.rb
+++ b/test/test_class_spec.rb
@@ -7,6 +7,12 @@ require 'minitest/autorun'
 require 'wrapture'
 
 class ClassSpecTest < Minitest::Test
+  def test_invalid_type
+    assert_raises(Wrapture::InvalidSpecKey) do
+      Wrapture::ClassSpec.new(load_fixture('invalid_type_class'))
+    end
+  end
+
   def test_normalize
     test_spec = load_fixture('minimal_class')
 

--- a/test/test_pointer_class.rb
+++ b/test/test_pointer_class.rb
@@ -31,7 +31,8 @@ class ClassSpecTest < Minitest::Test
     classes = spec.generate_wrappers
     validate_wrapper_results(test_spec, classes)
 
-    assert(file_contains_match('ExplicitPointerWrapper.hpp', 'struct basic_struct \*equivalent;'))
+    declaration = 'struct basic_struct \*equivalent;'
+    assert(file_contains_match('ExplicitPointerWrapper.hpp', declaration))
 
     File.delete(*classes)
   end

--- a/test/test_pointer_class.rb
+++ b/test/test_pointer_class.rb
@@ -23,6 +23,19 @@ require 'minitest/autorun'
 require 'wrapture'
 
 class ClassSpecTest < Minitest::Test
+  def test_explicit_class
+    test_spec = load_fixture('explicit_pointer_class')
+
+    spec = Wrapture::ClassSpec.new(test_spec)
+
+    classes = spec.generate_wrappers
+    validate_wrapper_results(test_spec, classes)
+
+    assert(file_contains_match('ExplicitPointerWrapper.hpp', 'struct basic_struct \*equivalent;'))
+
+    File.delete(*classes)
+  end
+
   def test_overriding_constructor
     test_spec = load_fixture('constructor_class')
 


### PR DESCRIPTION
Wrapture infers whether provided specs are wrappers for structs or pointers to them, but in situations where there is not enough information specified it may be incorrect. The addition of the type property for class specifications allows this information to be explicitly provided to address these cases.