### PR TITLE
skip unnecessary return casts

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Python class generation.
  - Perl class generation.
 
-## [0.3.0] - 2019-11-28
+## [0.3.0] - 2019-12-26
 ### Added
  - Examples of basic usage and features.
  - Option to give a class-level include list.
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    family of functions.
  - Classes can be explicitly specified as pointer or struct wrapping classes
    using the `type` property.
+ - Return values are not casted if the generated function and wrapped function
+   have the same return type.
 
 ### Fixed
  - `bin/wrapture` is now executable.

--- a/lib/wrapture/function_spec.rb
+++ b/lib/wrapture/function_spec.rb
@@ -160,18 +160,16 @@ module Wrapture
     def definition(class_name)
       yield "#{return_prefix}#{class_name}::#{signature} {"
 
-      wrapped_call = String.new
-      if returns_value?
-        wrapped_call << "return #{return_cast} ( "
-      elsif @constructor
-        wrapped_call << 'this->equivalent = '
-      end
+      call = @wrapped.call_from(self)
+      call_line = if @constructor
+                    "this->equivalent = #{call}"
+                  elsif returns_value?
+                    "return #{return_cast} ( #{call} )"
+                  else
+                    call
+                  end
 
-      wrapped_call << @wrapped.call_from(self)
-
-      wrapped_call << ' )' if returns_value?
-
-      yield "  #{wrapped_call};"
+      yield "  #{call_line};"
       yield '}'
     end
 

--- a/lib/wrapture/function_spec.rb
+++ b/lib/wrapture/function_spec.rb
@@ -164,7 +164,7 @@ module Wrapture
       call_line = if @constructor
                     "this->equivalent = #{call}"
                   elsif returns_value?
-                    "return #{return_cast} ( #{call} )"
+                    "return #{return_cast(call)}"
                   else
                     call
                   end
@@ -203,11 +203,13 @@ module Wrapture
     end
 
     # The function to use to create the return value of the function.
-    def return_cast
-      if @spec['return']['overloaded']
-        "new#{@spec['return']['type'].chomp('*').strip}"
+    def return_cast(value)
+      if @spec['return']['type'] == @wrapped.return_val_type
+        value
+      elsif @spec['return']['overloaded']
+        "new#{@spec['return']['type'].chomp('*').strip} ( #{value} )"
       else
-        @spec['return']['type']
+        "#{@spec['return']['type']} ( #{value} )"
       end
     end
 

--- a/lib/wrapture/wrapped_function_spec.rb
+++ b/lib/wrapture/wrapped_function_spec.rb
@@ -33,6 +33,11 @@ module Wrapture
 
       normalized['includes'] = Wrapture.normalize_includes(spec['includes'])
 
+      unless spec.key?('return')
+        normalized['return'] = {}
+        normalized['return']['type'] = 'void'
+      end
+
       normalized
     end
 

--- a/lib/wrapture/wrapped_function_spec.rb
+++ b/lib/wrapture/wrapped_function_spec.rb
@@ -1,4 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+
 # frozen_string_literal: true
+
+# Copyright 2019 Joel E. Anderson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 module Wrapture
   # A description of a function to be wrapped by another language.
@@ -53,6 +69,11 @@ module Wrapture
     # A list of includes required for this function call.
     def includes
       @spec['includes'].dup
+    end
+
+    # A string with the type of the return value.
+    def return_val_type
+      @spec['return']['type']
     end
   end
 end

--- a/test/fixtures/no_cast_function.yml
+++ b/test/fixtures/no_cast_function.yml
@@ -1,0 +1,7 @@
+name: "BasicFunction1"
+return:
+  type: "const char *"
+wrapped-function:
+  name: "underlying_basic_function"
+  return:
+    type: "const char *"

--- a/test/test_function_spec.rb
+++ b/test/test_function_spec.rb
@@ -1,4 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+
 # frozen_string_literal: true
+
+# Copyright 2019 Joel E. Anderson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 require 'helper'
 

--- a/test/test_function_spec.rb
+++ b/test/test_function_spec.rb
@@ -21,6 +21,19 @@ class FunctionSpecTest < Minitest::Test
     end
   end
 
+  def test_matching_return_types
+    test_spec = load_fixture('no_cast_function')
+
+    spec = Wrapture::FunctionSpec.new(test_spec)
+
+    call = test_spec['wrapped-function']['name']
+    spec.definition('NoSuchClass') do |line|
+      code = line.strip
+
+      assert(code.start_with?("return #{call}")) if code.start_with?('return')
+    end
+  end
+
   def test_versioned_function
     test_spec = load_fixture('versioned_function')
 


### PR DESCRIPTION
If a function and its wrapped function return the same type, then there is no need to cast the return value. 