### PR TITLE
add explicit bundler version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ matrix:
 
 before_install:
   - gem update --system --no-document
-  - gem install bundler --no-document
+  - gem install bundler -v 2.1.3 --no-document
 
 install:
   - bundle config set deployment 'true'


### PR DESCRIPTION
Add an explicit version to the Travis CI build in order to avoid
bugs in the rbx environment. The version of bundler in the
minimal.gemfile.lock and the rbx environments must match
exactly, or attempts to set bundler to deployment mode fail
with this cryptic error message: "can't find gem bundler
(>= 0.a) with executable bundle"