### PR TITLE
error on missing class name

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    parent's pointer constructor as the initializer for their own pointer
    constructor.
 
+### Fixed
+ - Classes with no `name` member raise a MissingSpecKey exception.
+
 ## [0.3.0] - 2020-01-01
 ### Added
  - Examples of basic usage and features.

--- a/lib/wrapture/class_spec.rb
+++ b/lib/wrapture/class_spec.rb
@@ -34,7 +34,7 @@ module Wrapture
     # it uses an unsupported version type, then an exception is raised.
     def self.normalize_spec_hash(spec)
       raise NoNamespace unless spec.key?('namespace')
-      raise MissingSpecKey.new('name key is required') unless spec.key?('name')
+      raise MissingSpecKey, 'name key is required' unless spec.key?('name')
 
       normalized = spec.dup
       normalized.default = []

--- a/lib/wrapture/class_spec.rb
+++ b/lib/wrapture/class_spec.rb
@@ -34,6 +34,7 @@ module Wrapture
     # it uses an unsupported version type, then an exception is raised.
     def self.normalize_spec_hash(spec)
       raise NoNamespace unless spec.key?('namespace')
+      raise MissingSpecKey.new('name key is required') unless spec.key?('name')
 
       normalized = spec.dup
       normalized.default = []

--- a/test/fixtures/no_name_class.yml
+++ b/test/fixtures/no_name_class.yml
@@ -1,0 +1,18 @@
+namespace: "wrapture_test"
+includes: "class_include.h"
+equivalent-struct:
+  name: "basic_struct"
+  includes: "folder/include_file_1.h"
+functions:
+  - name: "BasicFunction1"
+    params:
+      - name: "app_name"
+        type: "const char *"
+    wrapped-function:
+      name: "underlying_basic_function"
+      includes:
+        - "folder/include_file_2.h"
+        - "folder/include_file_3.h"
+      params:
+        - name: "equivalent-struct-pointer"
+        - name: "app_name"

--- a/test/test_class_spec.rb
+++ b/test/test_class_spec.rb
@@ -1,4 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+
 # frozen_string_literal: true
+
+# Copyright 2019-2020 Joel E. Anderson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 require 'helper'
 
@@ -10,6 +26,12 @@ class ClassSpecTest < Minitest::Test
   def test_invalid_type
     assert_raises(Wrapture::InvalidSpecKey) do
       Wrapture::ClassSpec.new(load_fixture('invalid_type_class'))
+    end
+  end
+
+  def test_no_name
+    assert_raises(Wrapture::MissingSpecKey) do
+      Wrapture::ClassSpec.new(load_fixture('no_name_class'))
     end
   end
 


### PR DESCRIPTION
Classes with no name member will throw a MissingSpecKey exception.