### PR TITLE
allow classes without an equivalent struct

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Python class generation.
  - Perl class generation.
 
-## [0.4.0] - 2020-01-08
+## [0.4.0] - 2020-02-27
 ### Added
  - Inequality conditions for rules (less-than, less-than-equal, greater-than,
    greater-than-equal).
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Pointer classes who's parent wraps the same equivalent struct will use the
    parent's pointer constructor as the initializer for their own pointer
    constructor.
+ - Classes may be defined with an equivalent struct.
 
 ### Fixed
  - Classes with no `name` member raise a MissingSpecKey exception.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Python class generation.
  - Perl class generation.
 
-## [0.4.0] - 2020-02-27
+## [0.4.0] - 2020-02-28
 ### Added
  - Inequality conditions for rules (less-than, less-than-equal, greater-than,
    greater-than-equal).
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Pointer classes who's parent wraps the same equivalent struct will use the
    parent's pointer constructor as the initializer for their own pointer
    constructor.
- - Classes may be defined with an equivalent struct.
+ - Classes may be defined without an equivalent struct.
 
 ### Fixed
  - Classes with no `name` member raise a MissingSpecKey exception.

--- a/test/fixtures/no_struct_class.yml
+++ b/test/fixtures/no_struct_class.yml
@@ -1,0 +1,7 @@
+name: "ClassWithNoStruct"
+namespace: "wrapture_test"
+functions:
+  - name: "StaticFunction"
+    static: true
+    wrapped-function:
+      name: "underlying_function"

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -136,6 +136,7 @@ def validate_indentation(filename)
 end
 
 def validate_members(spec, filename)
+  return unless spec.key?('equivalent-struct')
   return unless spec['equivalent-struct']['members']
 
   first_member_name = spec['equivalent-struct']['members'][0]['name']

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -137,9 +137,11 @@ end
 
 def validate_members(spec, filename)
   return unless spec.key?('equivalent-struct')
-  return unless spec['equivalent-struct']['members']
 
-  first_member_name = spec['equivalent-struct']['members'][0]['name']
+  equiv_struct = spec['equivalent-struct']
+  return unless equiv_struct['members']
+
+  first_member_name = equiv_struct['members'][0]['name']
 
   fail_msg = 'no constructor for struct members generated'
   assert file_contains_match(filename, first_member_name), fail_msg

--- a/test/test_class_spec.rb
+++ b/test/test_class_spec.rb
@@ -105,6 +105,17 @@ class ClassSpecTest < Minitest::Test
     File.delete(*classes)
   end
 
+  def test_class_with_no_struct
+    test_spec = load_fixture('no_struct_class')
+
+    spec = Wrapture::ClassSpec.new(test_spec)
+
+    generated_files = spec.generate_wrappers
+    validate_wrapper_results(test_spec, generated_files)
+
+    File.delete(*classes)
+  end
+
   def test_class_with_static_function
     test_spec = load_fixture('static_function_class')
 

--- a/test/test_class_spec.rb
+++ b/test/test_class_spec.rb
@@ -113,7 +113,7 @@ class ClassSpecTest < Minitest::Test
     generated_files = spec.generate_wrappers
     validate_wrapper_results(test_spec, generated_files)
 
-    File.delete(*classes)
+    File.delete(*generated_files)
   end
 
   def test_class_with_static_function


### PR DESCRIPTION
Classes may not necessarily need to have an equivalent struct, for example if they are simply a collection of static functions.