### PR TITLE
ignore rubinius ci build failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ matrix:
   allow_failures:
     - os: osx
       rvm: 2.3
+    - os: linux
+      rvm: rbx-3
   include:
     - os: linux
       dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ matrix:
       rvm: 2.3
     - os: linux
       rvm: rbx-3
+    - os: linux
+      rvm: rbx-4
   include:
     - os: linux
       dist: trusty


### PR DESCRIPTION
Rubinius Travis CI builds (rbx-3 and rbx-4) fail more often than they succeed, requiring manual retries to clear them. As these failures are due to the Rubinius build environment rather than Wrapture, they have been classified as an allowed failure so that they do not cause false failures in the continuous integration pipeline.