### PR TITLE
support documentation in specs

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Python class generation.
  - Perl class generation.
 
-## [0.4.0] - 2020-02-29
+## [0.4.0] - 2020-03-08
 ### Added
  - Inequality conditions for rules (less-than, less-than-equal, greater-than,
    greater-than-equal).
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    constructor.
  - Classes may be defined without an equivalent struct.
  - Specs can contain templatized sections to avoid duplicated sections.
- - Documentation can be added to generated code.
+ - Documentation can be added to generated classes, functions, and constants.
 
 ### Fixed
  - Classes with no `name` member raise a MissingSpecKey exception.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Python class generation.
  - Perl class generation.
 
-## [0.4.0] - 2020-02-28
+## [0.4.0] - 2020-02-29
 ### Added
  - Inequality conditions for rules (less-than, less-than-equal, greater-than,
    greater-than-equal).
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    constructor.
  - Classes may be defined without an equivalent struct.
  - Specs can contain templatized sections to avoid duplicated sections.
+ - Documentation can be added to generated code.
 
 ### Fixed
  - Classes with no `name` member raise a MissingSpecKey exception.

--- a/lib/wrapture.rb
+++ b/lib/wrapture.rb
@@ -19,6 +19,7 @@
 # Classes and functions for generating language wrappers
 module Wrapture
   require 'wrapture/action_spec'
+  require 'wrapture/comment'
   require 'wrapture/constant_spec'
   require 'wrapture/constants'
   require 'wrapture/class_spec'

--- a/lib/wrapture/class_spec.rb
+++ b/lib/wrapture/class_spec.rb
@@ -16,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require 'wrapture/comment'
 require 'wrapture/constant_spec'
 require 'wrapture/constants'
 require 'wrapture/function_spec'
@@ -35,6 +36,10 @@ module Wrapture
     def self.normalize_spec_hash(spec)
       raise NoNamespace unless spec.key?('namespace')
       raise MissingSpecKey, 'name key is required' unless spec.key?('name')
+
+      if spec['doc'] && !spec['doc'].is_a?(String)
+        raise InvalidSpecKey, 'the doc key must be a string'
+      end
 
       normalized = spec.dup
       normalized.default = []
@@ -127,6 +132,8 @@ module Wrapture
       @constants = @spec['constants'].map do |constant_spec|
         ConstantSpec.new(constant_spec)
       end
+
+      @doc = Comment.new(@spec['doc']) if @spec['doc']
 
       scope << self
       @scope = scope

--- a/lib/wrapture/class_spec.rb
+++ b/lib/wrapture/class_spec.rb
@@ -36,10 +36,7 @@ module Wrapture
     def self.normalize_spec_hash(spec)
       raise NoNamespace unless spec.key?('namespace')
       raise MissingSpecKey, 'name key is required' unless spec.key?('name')
-
-      if spec['doc'] && !spec['doc'].is_a?(String)
-        raise InvalidSpecKey, 'the doc key must be a string'
-      end
+      Comment.validate_doc(spec['doc']) if spec.key?('doc')
 
       normalized = spec.dup
       normalized.default = []

--- a/lib/wrapture/class_spec.rb
+++ b/lib/wrapture/class_spec.rb
@@ -90,6 +90,7 @@ module Wrapture
     # equivalent-struct:: a hash describing the struct this class wraps
     #
     # The following keys are optional:
+    # doc:: a string containing the documentation for this class
     # constructors:: a list of function specs that can create this class
     # destructor:: a function spec for the destructor of the class
     # functions:: a list of function specs

--- a/lib/wrapture/class_spec.rb
+++ b/lib/wrapture/class_spec.rb
@@ -276,7 +276,7 @@ module Wrapture
       overload_declaration { |line| yield "    #{line}" }
 
       @functions.each do |func|
-        yield "    #{func.declaration};"
+        func.declaration { |line| yield "    #{line}" }
       end
 
       yield '  };' # end of class

--- a/lib/wrapture/class_spec.rb
+++ b/lib/wrapture/class_spec.rb
@@ -36,6 +36,7 @@ module Wrapture
     def self.normalize_spec_hash(spec)
       raise NoNamespace unless spec.key?('namespace')
       raise MissingSpecKey, 'name key is required' unless spec.key?('name')
+
       Comment.validate_doc(spec['doc']) if spec.key?('doc')
 
       normalized = spec.dup

--- a/lib/wrapture/class_spec.rb
+++ b/lib/wrapture/class_spec.rb
@@ -133,7 +133,7 @@ module Wrapture
         ConstantSpec.new(constant_spec)
       end
 
-      @doc = Comment.new(@spec['doc']) if @spec['doc']
+      @doc = @spec.key?('doc') ? Comment.new(@spec['doc']) : nil
 
       scope << self
       @scope = scope
@@ -246,6 +246,7 @@ module Wrapture
       yield "namespace #{@spec['namespace']} {"
       yield
 
+      documentation { |line| yield "  #{line}" }
       parent = if child?
                  ": public #{parent_name} "
                else
@@ -365,6 +366,11 @@ module Wrapture
       includes.concat(overload_definition_includes)
 
       includes.uniq
+    end
+
+    # Yields the class documentation one line at a time.
+    def documentation
+      @doc.format_as_doxygen {|line| yield line} if @doc
     end
 
     # Yields the declaration of the equivalent member if this class has one.

--- a/lib/wrapture/class_spec.rb
+++ b/lib/wrapture/class_spec.rb
@@ -256,7 +256,7 @@ module Wrapture
 
       yield unless @constants.empty?
       @constants.each do |const|
-        yield "    #{const.declaration};"
+        const.declaration { |line| yield "    #{line}" }
       end
 
       yield

--- a/lib/wrapture/class_spec.rb
+++ b/lib/wrapture/class_spec.rb
@@ -370,7 +370,7 @@ module Wrapture
 
     # Yields the class documentation one line at a time.
     def documentation
-      @doc.format_as_doxygen {|line| yield line} if @doc
+      @doc&.format_as_doxygen(max_line_length: 78) { |line| yield line }
     end
 
     # Yields the declaration of the equivalent member if this class has one.

--- a/lib/wrapture/comment.rb
+++ b/lib/wrapture/comment.rb
@@ -30,10 +30,31 @@ module Wrapture
     end
 
     # Yields each line of the comment formatted as specified.
-    def format(first_line: '', last_line: '')
-      yield first_line
-      yield @text
-      yield last_line
+    def format(line_prefix: '// ', first_line: nil, last_line: nil,
+               max_line_length: 80)
+      yield first_line if first_line
+
+      @text.each_line do |line|
+        running_line = line_prefix.dup
+        line.scan(/\S+/) do |word|
+          if running_line.length + word.length > max_line_length
+            yield running_line.chomp
+            running_line = line_prefix.dup + word + ' '
+          else
+            running_line << word << ' '
+          end
+        end
+        yield running_line.chomp
+      end
+
+      yield last_line if last_line
+    end
+
+    # Yields each line of the comment formatted using Doxygen style.
+    def format_as_doxygen
+      format(line_prefix: ' * ', first_line: '/**', last_line: ' */') do |line|
+        yield line
+      end
     end
   end
 end

--- a/lib/wrapture/comment.rb
+++ b/lib/wrapture/comment.rb
@@ -18,12 +18,16 @@
 # limitations under the License.
 #++
 
-module Wrapture
-  # A comment that can be inserted in generated source code.
+module Wrapture  # A comment that can be inserted in generated source code.
   #
   # Comments are primarily used to insert documentation about generated code for
   # documentation generation tools such as Doxygen.
   class Comment
+    # Validates a doc string.
+    def self.validate_doc(doc)
+      raise InvalidDoc, 'a doc must be a string' unless doc.is_a?(String)
+    end
+
     # Creates a comment from a string.
     def initialize(comment)
       @text = comment

--- a/lib/wrapture/comment.rb
+++ b/lib/wrapture/comment.rb
@@ -34,18 +34,31 @@ module Wrapture
                max_line_length: 80)
       yield first_line if first_line
 
+      running_line = line_prefix.dup
+      newline_mode = false
       @text.each_line do |line|
-        running_line = line_prefix.dup
+        if line.strip.empty?
+          if !newline_mode
+            yield running_line.rstrip
+            yield line_prefix.rstrip
+            running_line = line_prefix.dup
+            newline_mode = true
+          end
+        else
+          newline_mode = false
+        end
+
         line.scan(/\S+/) do |word|
           if running_line.length + word.length > max_line_length
-            yield running_line.chomp
+            yield running_line.rstrip
             running_line = line_prefix.dup + word + ' '
           else
             running_line << word << ' '
           end
         end
-        yield running_line.chomp
       end
+
+      yield running_line.rstrip
 
       yield last_line if last_line
     end

--- a/lib/wrapture/comment.rb
+++ b/lib/wrapture/comment.rb
@@ -66,7 +66,7 @@ module Wrapture
     # the maximum length. The caller must strip these off.
     def paragraphs(line_length)
       running_line = String.new
-      newline_mode = false
+      newline_mode = true
       @text.each_line do |line|
         if line.strip.empty?
           unless newline_mode

--- a/lib/wrapture/comment.rb
+++ b/lib/wrapture/comment.rb
@@ -28,5 +28,12 @@ module Wrapture
     def initialize(comment)
       @text = comment
     end
+
+    # Yields each line of the comment formatted as specified.
+    def format(first_line: '', last_line: '')
+      yield first_line
+      yield @text
+      yield last_line
+    end
   end
 end

--- a/lib/wrapture/comment.rb
+++ b/lib/wrapture/comment.rb
@@ -51,8 +51,9 @@ module Wrapture
     end
 
     # Yields each line of the comment formatted using Doxygen style.
-    def format_as_doxygen
-      format(line_prefix: ' * ', first_line: '/**', last_line: ' */') do |line|
+    def format_as_doxygen(max_line_length: 80)
+      format(line_prefix: ' * ', first_line: '/**',
+             last_line: ' */', max_line_length: max_line_length) do |line|
         yield line
       end
     end

--- a/lib/wrapture/comment.rb
+++ b/lib/wrapture/comment.rb
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# frozen_string_literal: true
+
+#--
+# Copyright 2020 Joel E. Anderson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#++
+
+module Wrapture
+  # A comment that can be inserted in generated source code.
+  #
+  # Comments are primarily used to insert documentation about generated code for
+  # documentation generation tools such as Doxygen.
+  class Comment
+    # Creates a comment from a string.
+    def initialize(comment)
+      @text = comment
+    end
+  end
+end

--- a/lib/wrapture/comment.rb
+++ b/lib/wrapture/comment.rb
@@ -18,7 +18,8 @@
 # limitations under the License.
 #++
 
-module Wrapture  # A comment that can be inserted in generated source code.
+module Wrapture
+  # A comment that can be inserted in generated source code.
   #
   # Comments are primarily used to insert documentation about generated code for
   # documentation generation tools such as Doxygen.

--- a/lib/wrapture/constant_spec.rb
+++ b/lib/wrapture/constant_spec.rb
@@ -26,6 +26,9 @@ module Wrapture
     # value:: the value to assign to the constant
     # includes::  a list of includes that need to be added in order for this
     # constant to be valid (for example, includes for the type and value).
+    #
+    # The following keys are optional:
+    # doc:: a string containing the documentation for this constant
     def initialize(spec)
       @spec = ConstantSpec.normalize_spec_hash spec
     end

--- a/lib/wrapture/constant_spec.rb
+++ b/lib/wrapture/constant_spec.rb
@@ -1,4 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+
 # frozen_string_literal: true
+
+#--
+# Copyright 2019-2020 Joel E. Anderson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#++
 
 require 'wrapture/comment'
 require 'wrapture/normalize'

--- a/lib/wrapture/errors.rb
+++ b/lib/wrapture/errors.rb
@@ -3,7 +3,7 @@
 # frozen_string_literal: true
 
 #--
-# Copyright 2019 Joel E. Anderson
+# Copyright 2019-2020 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,6 +21,14 @@
 module Wrapture
   # An error from the Wrapture library
   class WraptureError < StandardError
+  end
+
+  # A documentation string is invalid.
+  class InvalidDoc < WraptureError
+    # Creates an InvalidDoc with the given message.
+    def initialize(message)
+      super(message)
+    end
   end
 
   # A template has been invoked in an unsupported way.

--- a/lib/wrapture/function_spec.rb
+++ b/lib/wrapture/function_spec.rb
@@ -100,7 +100,7 @@ module Wrapture
 
       comment = String.new
       comment << @spec['doc'] if @spec.key?('doc')
-      @spec['params'].filter { |param| param.key?('doc') }.each do |param|
+      @spec['params'].select { |param| param.key?('doc') }.each do |param|
         comment << "\n\n@param " << param['name'] << ' ' << param['doc']
       end
       if @spec['return'].key?('doc')

--- a/lib/wrapture/function_spec.rb
+++ b/lib/wrapture/function_spec.rb
@@ -66,13 +66,25 @@ module Wrapture
     # params:: a list of parameter specifications
     # wrapped-function:: a hash describing the function to be wrapped
     #
+    # Each parameter specification must have a 'name' key with the name of the
+    # parameter and a 'type' key with its type. It may optionally have an
+    # 'includes' key with includes that are required (for example to support the
+    # type) and/or a 'doc' key with documentation of the parameter.
+    #
     # The wrapped-function must have a 'name' key with the name of the function,
     # and a 'params' key with a list of parameters (each a hash with a 'name'
     # and 'type' key). Optionally, it may also include an 'includes' key with a
     # list of includes that are needed for this function to compile.
     #
     # The following keys are optional:
-    # static:: set to true if this is a static function.
+    # doc:: a string containing the documentation for this function
+    # return:: a specification of the return value for this function
+    # static:: set to true if this is a static function
+    #
+    # The return specification may have either a 'type' key with the name of the
+    # type the function returns, and/or a 'doc' key with documentation on the
+    # return value itself. If neither of these is needed, then the return
+    # specification may simply be omitted.
     def initialize(spec, owner = Scope.new, constructor: false,
                    destructor: false)
       @owner = owner

--- a/lib/wrapture/function_spec.rb
+++ b/lib/wrapture/function_spec.rb
@@ -16,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require 'wrapture/comment'
 require 'wrapture/constants'
 require 'wrapture/errors'
 require 'wrapture/scope'
@@ -30,9 +31,7 @@ module Wrapture
     # set missing keys to their default values (for example, an empty list if no
     # includes are given).
     def self.normalize_spec_hash(spec)
-      if spec['doc'] && !spec['doc'].is_a?(String)
-        raise InvalidSpecKey, 'the doc key must be a string'
-      end
+      Comment.validate_doc(spec['doc']) if spec.key?('doc')
 
       normalized = spec.dup
       param_types = {}

--- a/lib/wrapture/function_spec.rb
+++ b/lib/wrapture/function_spec.rb
@@ -154,9 +154,13 @@ module Wrapture
       "#{@spec['name']}( #{param_list} )"
     end
 
-    # The declaration of the function.
+    # Yields each line of the declaration of the function, including any
+    # documentation.
     def declaration
-      return signature if @constructor || @destructor
+      if @constructor || @destructor
+        yield "#{signature};"
+        return
+      end
 
       modifier_prefix = if @spec['static']
                           'static '
@@ -165,7 +169,7 @@ module Wrapture
                         else
                           ''
                         end
-      "#{modifier_prefix}#{@spec['return']['type']} #{signature}"
+      yield "#{modifier_prefix}#{@spec['return']['type']} #{signature};"
     end
 
     # Gives the definition of the function to a block, line by line.

--- a/lib/wrapture/function_spec.rb
+++ b/lib/wrapture/function_spec.rb
@@ -30,6 +30,10 @@ module Wrapture
     # set missing keys to their default values (for example, an empty list if no
     # includes are given).
     def self.normalize_spec_hash(spec)
+      if spec['doc'] && !spec['doc'].is_a?(String)
+        raise InvalidSpecKey, 'the doc key must be a string'
+      end
+
       normalized = spec.dup
       param_types = {}
 
@@ -92,6 +96,7 @@ module Wrapture
       @wrapped = WrappedFunctionSpec.new(spec['wrapped-function'])
       @constructor = constructor
       @destructor = destructor
+      @doc = @spec.key?('doc') ? Comment.new(@spec['doc']) : nil
     end
 
     # True if the function is a constructor, false otherwise.
@@ -157,6 +162,8 @@ module Wrapture
     # Yields each line of the declaration of the function, including any
     # documentation.
     def declaration
+      @doc&.format_as_doxygen(max_line_length: 78) { |line| yield line }
+
       if @constructor || @destructor
         yield "#{signature};"
         return

--- a/lib/wrapture/function_spec.rb
+++ b/lib/wrapture/function_spec.rb
@@ -100,15 +100,11 @@ module Wrapture
 
       comment = String.new
       comment << @spec['doc'] if @spec.key?('doc')
-      @spec['params'].each do |param|
-        if param.key?('doc')
-          comment << "\n\n" unless comment.empty?
-          comment << '@param ' << param['name'] << ' ' << param['doc']
-        end
+      @spec['params'].filter { |param| param.key?('doc') }.each do |param|
+        comment << "\n\n@param " << param['name'] << ' ' << param['doc']
       end
       if @spec['return'].key?('doc')
-        comment << "\n\n" unless comment.empty?
-        comment << '@return ' << @spec['return']['doc']
+        comment << "\n\n@return " << @spec['return']['doc']
       end
       @doc = comment.empty? ? nil : Comment.new(comment)
     end

--- a/lib/wrapture/function_spec.rb
+++ b/lib/wrapture/function_spec.rb
@@ -172,7 +172,7 @@ module Wrapture
     # Yields each line of the declaration of the function, including any
     # documentation.
     def declaration
-      @doc&.format_as_doxygen(max_line_length: 78) { |line| yield line }
+      @doc&.format_as_doxygen(max_line_length: 76) { |line| yield line }
 
       if @constructor || @destructor
         yield "#{signature};"

--- a/test/fixtures/documented_class.yml
+++ b/test/fixtures/documented_class.yml
@@ -1,0 +1,12 @@
+name: "DocumentedClass"
+namespace: "wrapture_test"
+doc: |2
+  DocumentedClass is a simple wrapper class that demonstrates how documentation
+  works in generated wrappers. This documentation will be added into the
+  declaration of the class, and can then be picked up by documentation
+  generators like Doxygen.
+  
+  Multiple paragraphs should be fully supported by this documentation style.
+  This will result in multiple paragraphs in the generated output.
+equivalent-struct:
+  name: "documented"

--- a/test/fixtures/documented_constant.yml
+++ b/test/fixtures/documented_constant.yml
@@ -1,0 +1,5 @@
+name: "TEST_CONSTANT"
+doc: "the most magical number of all times. ConstantDocIdentifier"
+type: "int"
+value: "455"
+includes: "my_include.h"

--- a/test/fixtures/documented_function.yml
+++ b/test/fixtures/documented_function.yml
@@ -4,7 +4,7 @@ doc: |2
   Parameters and return values can also be documented, but they should be done
   separately in their own specs so that the formatting specifics of different
   target languages are not injected into the specification.
-
+  
   FunctionDocIdentifier
 params:
   - name: "app_name"

--- a/test/fixtures/documented_function.yml
+++ b/test/fixtures/documented_function.yml
@@ -1,0 +1,21 @@
+name: "BasicFunction1"
+doc: |2
+  This is a function created to test the documentation features of Wrapture.
+  Parameters and return values can also be documented, but they should be done
+  separately in their own specs so that the formatting specifics of different
+  target languages are not injected into the specification.
+
+  FunctionDocIdentifier
+params:
+  - name: "app_name"
+    type: "const char *"
+    doc: "the name of an application. ParamDocIdentifier"
+return:
+  doc: "returns a value. ReturnDocIdentifier"
+wrapped-function:
+  name: "underlying_basic_function"
+  includes:
+    - "folder/include_file_2.h"
+    - "folder/include_file_3.h"
+  params:
+    - name: "app_name"

--- a/test/fixtures/documented_params.yml
+++ b/test/fixtures/documented_params.yml
@@ -1,0 +1,12 @@
+name: "BasicFunction1"
+params:
+  - name: "app_name"
+    type: "const char *"
+    doc: "the name of an application. ParamDocIdentifier"
+wrapped-function:
+  name: "underlying_basic_function"
+  includes:
+    - "folder/include_file_2.h"
+    - "folder/include_file_3.h"
+  params:
+    - name: "app_name"

--- a/test/fixtures/invalid/class_with_invalid_doc.yml
+++ b/test/fixtures/invalid/class_with_invalid_doc.yml
@@ -1,0 +1,5 @@
+name: "MinimalClass"
+namespace: "wrapture_test"
+doc: 3
+equivalent-struct:
+  name: "minimal_struct"

--- a/test/test_class_spec.rb
+++ b/test/test_class_spec.rb
@@ -105,6 +105,25 @@ class ClassSpecTest < Minitest::Test
     File.delete(*classes)
   end
 
+  def test_class_with_documentation
+    test_spec = load_fixture('documented_class')
+
+    spec = Wrapture::ClassSpec.new(test_spec)
+
+    generated_files = spec.generate_wrappers
+    validate_wrapper_results(test_spec, generated_files)
+
+    File.open('DocumentedClass.hpp').each do |line|
+      if line.lstrip.start_with?('/**', '*')
+        refute(line.chomp.end_with?(' '))
+      end
+    end
+
+    assert(file_contains_match('DocumentedClass.hpp', '\s\*$'))
+
+    #File.delete(*generated_files)
+  end
+
   def test_class_with_no_struct
     test_spec = load_fixture('no_struct_class')
 

--- a/test/test_class_spec.rb
+++ b/test/test_class_spec.rb
@@ -116,12 +116,13 @@ class ClassSpecTest < Minitest::Test
     File.open('DocumentedClass.hpp').each do |line|
       if line.lstrip.start_with?('/**', '*')
         refute(line.chomp.end_with?(' '))
+        assert(line.chomp.length <= 80)
       end
     end
 
     assert(file_contains_match('DocumentedClass.hpp', '\s\*$'))
 
-    #File.delete(*generated_files)
+    File.delete(*generated_files)
   end
 
   def test_class_with_no_struct

--- a/test/test_constant_spec.rb
+++ b/test/test_constant_spec.rb
@@ -13,6 +13,22 @@ class ConstantSpecTest < Minitest::Test
     Wrapture::ConstantSpec.new(test_spec)
   end
 
+  def test_documentation
+    test_spec = load_fixture('documented_constant')
+
+    constant = Wrapture::ConstantSpec.new(test_spec)
+
+    comment = String.new
+    constant.declaration do |line|
+      next if line.nil? || !line.lstrip.start_with?('/**', '*')
+
+      comment << line << "\n"
+    end
+
+    refute(comment.empty?)
+    assert(comment.include?('ConstantDocIdentifier'))
+  end
+
   def test_future_spec_version
     test_spec = load_fixture('future_version_constant')
 

--- a/test/test_function_spec.rb
+++ b/test/test_function_spec.rb
@@ -29,6 +29,21 @@ class FunctionSpecTest < Minitest::Test
     Wrapture::FunctionSpec.new(test_spec)
   end
 
+  def test_documentation
+    test_spec = load_fixture('documented_function')
+
+    spec = Wrapture::FunctionSpec.new(test_spec)
+
+    doc_found = false
+    spec.definition('NoSuchClass') do |line|
+      next if line.nil? || !line.lstrip.start_with?('/**', '*')
+
+      doc_found = true
+    end
+
+    assert(doc_found)
+  end
+
   def test_exception_throwing_function
     test_spec = load_fixture('exception_throwing_function')
 

--- a/test/test_function_spec.rb
+++ b/test/test_function_spec.rb
@@ -83,6 +83,23 @@ class FunctionSpecTest < Minitest::Test
     end
   end
 
+  def test_only_documented_params
+    test_spec = load_fixture('documented_params')
+
+    spec = Wrapture::FunctionSpec.new(test_spec)
+
+    comment = String.new
+    spec.declaration do |line|
+      next if line.nil? || !line.lstrip.start_with?('/**', '*')
+
+      refute_match(/^\s*\*\s*$/, line)
+      comment << line << "\n"
+    end
+
+    refute(comment.empty?)
+    assert(comment.include?('ParamDocIdentifier'))
+  end
+
   def test_versioned_function
     test_spec = load_fixture('versioned_function')
 

--- a/test/test_function_spec.rb
+++ b/test/test_function_spec.rb
@@ -35,7 +35,7 @@ class FunctionSpecTest < Minitest::Test
     spec = Wrapture::FunctionSpec.new(test_spec)
 
     doc_found = false
-    spec.definition('NoSuchClass') do |line|
+    spec.declaration do |line|
       next if line.nil? || !line.lstrip.start_with?('/**', '*')
 
       doc_found = true

--- a/test/test_function_spec.rb
+++ b/test/test_function_spec.rb
@@ -34,14 +34,17 @@ class FunctionSpecTest < Minitest::Test
 
     spec = Wrapture::FunctionSpec.new(test_spec)
 
-    doc_found = false
+    comment = String.new
     spec.declaration do |line|
       next if line.nil? || !line.lstrip.start_with?('/**', '*')
 
-      doc_found = true
+      comment << line << "\n"
     end
 
-    assert(doc_found)
+    refute(comment.empty?)
+    assert(comment.include?('FunctionDocIdentifier'))
+    assert(comment.include?('ParamDocIdentifier'))
+    assert(comment.include?('ReturnDocIdentifier'))
   end
 
   def test_exception_throwing_function

--- a/test/test_invalid.rb
+++ b/test/test_invalid.rb
@@ -26,7 +26,7 @@ class InvalidTest < Minitest::Test
   def test_class_with_invalid_doc
     test_spec = load_fixture('invalid/class_with_invalid_doc')
 
-    assert_raises(Wrapture::InvalidSpecKey) do
+    assert_raises(Wrapture::InvalidDoc) do
       Wrapture::ClassSpec.new(test_spec)
     end
   end

--- a/test/test_invalid.rb
+++ b/test/test_invalid.rb
@@ -23,6 +23,14 @@ require 'minitest/autorun'
 require 'wrapture'
 
 class InvalidTest < Minitest::Test
+  def test_class_with_invalid_doc
+    test_spec = load_fixture('invalid/class_with_invalid_doc')
+
+    assert_raises(Wrapture::InvalidSpecKey) do
+      Wrapture::ClassSpec.new(test_spec)
+    end
+  end
+
   def test_invalid_virtual_key
     test_spec = load_fixture('invalid/invalid_virtual_key')
 


### PR DESCRIPTION
Specs for classes, functions, and constants can include a 'doc' key that will be used to generate doxygen-style comments in the generated code.