### PR TITLE
add self-reference return type

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Python class generation.
  - Perl class generation.
 
-## [0.4.0] - 2020-03-08
+## [0.4.0] - 2020-03-19
 ### Added
  - Inequality conditions for rules (less-than, less-than-equal, greater-than,
    greater-than-equal).
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Classes may be defined without an equivalent struct.
  - Specs can contain templatized sections to avoid duplicated sections.
  - Documentation can be added to generated classes, functions, and constants.
+ - Return type may be `self-reference` to facilitate method chaining.
 
 ### Fixed
  - Classes with no `name` member raise a MissingSpecKey exception.

--- a/lib/wrapture/constants.rb
+++ b/lib/wrapture/constants.rb
@@ -2,6 +2,7 @@
 
 # frozen_string_literal: true
 
+#--
 # Copyright 2019-2020 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +16,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#++
 
 module Wrapture
   # A string denoting an equivalent struct type or value.
@@ -25,6 +27,9 @@ module Wrapture
 
   # A string denoting the return value of a wrapped function call.
   RETURN_VALUE_KEYWORD = 'return-value'
+
+  # A string denoting a reference to the object a method is called on.
+  SELF_REFERENCE_KEYWORD = 'self-reference'
 
   # A string denoting a reference to a template.
   TEMPLATE_USE_KEYWORD = 'use-template'

--- a/test/fixtures/self_reference_class.yml
+++ b/test/fixtures/self_reference_class.yml
@@ -1,0 +1,18 @@
+name: "BasicClass"
+namespace: "wrapture_test"
+includes: "class_include.h"
+equivalent-struct:
+  name: "basic_struct"
+  includes: "folder/include_file_1.h"
+functions:
+  - name: "BasicFunction1"
+    params:
+      - name: "app_name"
+        type: "const char *"
+    return:
+      type: "self-reference"
+    wrapped-function:
+      name: "underlying_basic_function"
+      params:
+        - name: "equivalent-struct-pointer"
+        - name: "app_name"

--- a/test/test_self_reference.rb
+++ b/test/test_self_reference.rb
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# frozen_string_literal: true
+
+# Copyright 2019-2020 Joel E. Anderson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'helper'
+
+require 'fixture'
+require 'minitest/autorun'
+require 'wrapture'
+
+class SelfReferenceTest < Minitest::Test
+  def test_self_reference_function
+    test_spec = load_fixture('self_reference_class')
+
+    spec = Wrapture::ClassSpec.new(test_spec)
+
+    classes = spec.generate_wrappers
+    validate_wrapper_results(test_spec, classes)
+
+    source_file = "#{test_spec['name']}.cpp"
+
+    forbidden = Wrapture::SELF_REFERENCE_KEYWORD
+    assert(!file_contains_match(source_file, forbidden))
+
+    assert(file_contains_match(source_file, /return \*this;/))
+
+    File.delete(*classes)
+  end
+end

--- a/test/test_self_reference.rb
+++ b/test/test_self_reference.rb
@@ -28,16 +28,18 @@ class SelfReferenceTest < Minitest::Test
 
     spec = Wrapture::ClassSpec.new(test_spec)
 
-    classes = spec.generate_wrappers
-    validate_wrapper_results(test_spec, classes)
-
-    source_file = "#{test_spec['name']}.cpp"
+    generated_files = spec.generate_wrappers
+    validate_wrapper_results(test_spec, generated_files)
 
     forbidden = Wrapture::SELF_REFERENCE_KEYWORD
-    assert(!file_contains_match(source_file, forbidden))
+    generated_files.each do |filename|
+      assert(!file_contains_match(filename, forbidden),
+             "#{filename} should not contain '#{forbidden}'")
+    end
 
+    source_file = "#{test_spec['name']}.cpp"
     assert(file_contains_match(source_file, /return \*this;/))
 
-    File.delete(*classes)
+    File.delete(*generated_files)
   end
 end


### PR DESCRIPTION
Allow return type to be set to 'self-reference' so that a reference to the instance of a method call may be returned. This allows the creation of functions that support method chaining idioms.