### PR TITLE
support class references and pointers

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Python class generation.
  - Perl class generation.
 
-## [0.4.0] - 2020-03-19
+## [0.4.0] - 2020-03-20
 ### Added
  - Inequality conditions for rules (less-than, less-than-equal, greater-than,
    greater-than-equal).
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Specs can contain templatized sections to avoid duplicated sections.
  - Documentation can be added to generated classes, functions, and constants.
  - Return type may be `self-reference` to facilitate method chaining.
+ - Conversions can be made from references to wrapped classes to their
+   equivalent types.
 
 ### Fixed
  - Classes with no `name` member raise a MissingSpecKey exception.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -22,8 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Specs can contain templatized sections to avoid duplicated sections.
  - Documentation can be added to generated classes, functions, and constants.
  - Return type may be `self-reference` to facilitate method chaining.
- - Conversions can be made from references to wrapped classes to their
-   equivalent types.
+ - Conversions can be made from references and pointers to wrapped classes to
+   their equivalent structs.
 
 ### Fixed
  - Classes with no `name` member raise a MissingSpecKey exception.

--- a/lib/wrapture/class_spec.rb
+++ b/lib/wrapture/class_spec.rb
@@ -137,6 +137,9 @@ module Wrapture
       @scope = scope
     end
 
+    # Returns a cast of an instance of this class with the provided name to the
+    # specified type. Optionally the from parameter may hold the type of the
+    # instance, either a reference or a pointer.
     def cast(instance, to, from = name)
       member_access = from.end_with?('*') ? '->' : '.'
 

--- a/lib/wrapture/class_spec.rb
+++ b/lib/wrapture/class_spec.rb
@@ -137,38 +137,16 @@ module Wrapture
       @scope = scope
     end
 
-    # Returns a cast of an instance of this class to the provided type, if
-    # possible.
-    def cast_to(name, type)
+    def cast(instance, to, from = name)
+      member_access = from.end_with?('*') ? '->' : '.'
+
       struct = "struct #{@struct.name}"
 
-      if [EQUIVALENT_STRUCT_KEYWORD, struct].include?(type)
-        equivalent_struct(name)
-      elsif [EQUIVALENT_POINTER_KEYWORD, "#{struct} *"].include?(type)
-        equivalent_struct_pointer(name)
+      if [EQUIVALENT_STRUCT_KEYWORD, struct].include?(to)
+        "#{'*' if pointer_wrapper?}#{instance}#{member_access}equivalent"
+      elsif [EQUIVALENT_POINTER_KEYWORD, "#{struct} *"].include?(to)
+        "#{'&' unless pointer_wrapper?}#{instance}#{member_access}equivalent"
       end
-    end
-
-    # Returns a cast of a pointer to an instance of this class to the provided
-    # type, if possible.
-    def cast_pointer_to(name, type)
-      struct = "struct #{@struct.name}"
-
-      if [EQUIVALENT_STRUCT_KEYWORD, struct].include?(type)
-        "#{'*' if pointer_wrapper?}#{name}->equivalent"
-      elsif [EQUIVALENT_POINTER_KEYWORD, "#{struct} *"].include?(type)
-        "#{'&' unless pointer_wrapper?}#{name}->equivalent"
-      end
-    end
-
-    # The equivalent struct of this class from an instance of it.
-    def equivalent_struct(instance_name)
-      "#{'*' if pointer_wrapper?}#{instance_name}.equivalent"
-    end
-
-    # A pointer to the equivalent struct of this class from an instance of it.
-    def equivalent_struct_pointer(instance_name)
-      "#{'&' unless pointer_wrapper?}#{instance_name}.equivalent"
     end
 
     # Generates the wrapper class declaration and definition files.

--- a/lib/wrapture/class_spec.rb
+++ b/lib/wrapture/class_spec.rb
@@ -149,6 +149,18 @@ module Wrapture
       end
     end
 
+    # Returns a cast of a pointer to an instance of this class to the provided
+    # type, if possible.
+    def cast_pointer_to(name, type)
+      struct = "struct #{@struct.name}"
+
+      if [EQUIVALENT_STRUCT_KEYWORD, struct].include?(type)
+        "#{'*' if pointer_wrapper?}#{name}->equivalent"
+      elsif [EQUIVALENT_POINTER_KEYWORD, "#{struct} *"].include?(type)
+        "#{'&' unless pointer_wrapper?}#{name}->equivalent"
+      end
+    end
+
     # The equivalent struct of this class from an instance of it.
     def equivalent_struct(instance_name)
       "#{'*' if pointer_wrapper?}#{instance_name}.equivalent"

--- a/lib/wrapture/function_spec.rb
+++ b/lib/wrapture/function_spec.rb
@@ -165,11 +165,9 @@ module Wrapture
             @owner.type?(used_param['type']) &&
             !param_spec['type'].nil?
         param_class = @owner.type(used_param['type'])
-        if used_param['type'].end_with?('*')
-          param_class.cast_pointer_to(used_param['name'], param_spec['type'])
-        else
-          param_class.cast_to(used_param['name'], param_spec['type'])
-        end
+        param_class.cast(used_param['name'],
+                         param_spec['type'],
+                         used_param['type'])
       else
         param_spec['value']
       end

--- a/lib/wrapture/function_spec.rb
+++ b/lib/wrapture/function_spec.rb
@@ -165,7 +165,11 @@ module Wrapture
             @owner.type?(used_param['type']) &&
             !param_spec['type'].nil?
         param_class = @owner.type(used_param['type'])
-        param_class.cast_to(used_param['name'], param_spec['type'])
+        if used_param['type'].end_with?('*')
+          param_class.cast_pointer_to(used_param['name'], param_spec['type'])
+        else
+          param_class.cast_to(used_param['name'], param_spec['type'])
+        end
       else
         param_spec['value']
       end

--- a/lib/wrapture/scope.rb
+++ b/lib/wrapture/scope.rb
@@ -80,16 +80,14 @@ module Wrapture
 
     # Returns the ClassSpec for the given type in the scope.
     def type(type)
-      @classes.find { |class_spec| class_spec.name == type }
+      base_type = type.delete('&*').strip
+      @classes.find { |class_spec| class_spec.name == base_type }
     end
 
     # Returns true if the given type is in the scope.
     def type?(type)
-      @classes.each do |class_spec|
-        return true if class_spec.name == type
-      end
-
-      false
+      base_type = type.delete('&*').strip
+      @classes.any? { |class_spec| class_spec.name == base_type }
     end
   end
 end

--- a/lib/wrapture/scope.rb
+++ b/lib/wrapture/scope.rb
@@ -80,14 +80,18 @@ module Wrapture
 
     # Returns the ClassSpec for the given type in the scope.
     def type(type)
-      base_type = type.delete('&*').strip
-      @classes.find { |class_spec| class_spec.name == base_type }
+      @classes.find { |class_spec| class_spec.name == base_type(type) }
     end
 
     # Returns true if the given type is in the scope.
     def type?(type)
-      base_type = type.delete('&*').strip
-      @classes.any? { |class_spec| class_spec.name == base_type }
+      @classes.any? { |class_spec| class_spec.name == base_type(type) }
+    end
+
+    private
+
+    def base_type(type)
+      type.delete('&*').strip
     end
   end
 end

--- a/test/fixtures/scope_with_pointer_param.yml
+++ b/test/fixtures/scope_with_pointer_param.yml
@@ -1,0 +1,39 @@
+classes:
+  - name: "Bullet"
+    namespace: "wrapture_test"
+    equivalent-struct:
+      name: "bullet_struct"
+      includes: "bullet_struct.h"
+    type: "pointer"
+  - name: "Rifle"
+    namespace: "wrapture_test"
+    equivalent-struct:
+      name: "rifle_struct"
+      includes: "rifle_struct.h"
+    functions:
+      - name: "load"
+        params:
+          - name: "bullet"
+            type: "Bullet *"
+            includes: "Bullet.hpp"
+        return:
+          type: "self-reference"
+        wrapped-function:
+          name: "load_rifle_with_bullet"
+          params:
+            - value: "equivalent-struct-pointer"
+            - type: "struct bullet_struct *"
+              value: "bullet"
+      - name: "fire"
+        params:
+          - name: "bullet"
+            type: "Bullet *"
+            includes: "Bullet.hpp"
+        return:
+          type: "self-reference"
+        wrapped-function:
+          name: "fire_bullet_from_rifle"
+          params:
+            - value: "equivalent-struct-pointer"
+            - type: "struct bullet_struct"
+              value: "bullet"

--- a/test/fixtures/scope_with_reference_param.yml
+++ b/test/fixtures/scope_with_reference_param.yml
@@ -1,0 +1,25 @@
+classes:
+  - name: "Bullet"
+    namespace: "wrapture_test"
+    equivalent-struct:
+      name: "bullet_struct"
+      includes: "bullet_struct.h"
+    type: "pointer"
+  - name: "Rifle"
+    namespace: "wrapture_test"
+    equivalent-struct:
+      name: "rifle_struct"
+      includes: "rifle_struct.h"
+    functions:
+      - name: "load"
+        params:
+          - name: "bullet"
+            type: "Bullet&"
+        return:
+          type: "self-reference"
+        wrapped-function:
+          name: "load_rifle_with_bullet"
+          params:
+            - value: "equivalent-struct-pointer"
+            - type: "struct bullet_struct *"
+              value: "bullet"

--- a/test/test_type_conversion.rb
+++ b/test/test_type_conversion.rb
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# frozen_string_literal: true
+
+# Copyright 2020 Joel E. Anderson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'helper'
+
+require 'fixture'
+require 'minitest/autorun'
+require 'wrapture'
+
+class TypeConversionTest < Minitest::Test
+  def test_reference_to_pointer
+    test_spec = load_fixture('scope_with_reference_param')
+
+    scope = Wrapture::Scope.new(test_spec)
+
+    generated_files = scope.generate_wrappers
+    validate_wrapper_results(test_spec, generated_files)
+
+    assert(file_contains_match("Rifle.cpp", /bullet\.equivalent/))
+
+    File.delete(*generated_files)
+  end
+end

--- a/test/test_type_conversion.rb
+++ b/test/test_type_conversion.rb
@@ -31,7 +31,7 @@ class TypeConversionTest < Minitest::Test
     generated_files = scope.generate_wrappers
     validate_wrapper_results(test_spec, generated_files)
 
-    assert(file_contains_match("Rifle.cpp", /bullet\.equivalent/))
+    assert(file_contains_match('Rifle.cpp', /bullet\.equivalent/))
 
     File.delete(*generated_files)
   end

--- a/test/test_type_conversion.rb
+++ b/test/test_type_conversion.rb
@@ -23,6 +23,19 @@ require 'minitest/autorun'
 require 'wrapture'
 
 class TypeConversionTest < Minitest::Test
+  def test_class_pointer_to_struct_pointer
+    test_spec = load_fixture('scope_with_pointer_param')
+
+    scope = Wrapture::Scope.new(test_spec)
+
+    generated_files = scope.generate_wrappers
+    validate_wrapper_results(test_spec, generated_files)
+
+    assert(file_contains_match('Rifle.cpp', /bullet->equivalent/))
+
+    File.delete(*generated_files)
+  end
+
   def test_reference_to_pointer
     test_spec = load_fixture('scope_with_reference_param')
 


### PR DESCRIPTION
Function parameters that are set to references or pointers to a wrapped class can be automatically converted to their equivalent struct in wrapped function calls. This makes it easy to define overloads for functions to accept different types of parameters without significant spec changes.