### PR TITLE
remove incorrect return types

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,11 @@ For a detailed look at the project's future, including planned features and bug
 fixes, check out the
 [roadmap](https://github.com/goatshriek/wrapture/blob/master/docs/roadmap.md).
 
+## [0.4.1] - 2020-04-24
+### Fixed
+ - Constructor and destructor definitions no longer have a type of 'void'
+   provided ([issue #72](https://github.com/goatshriek/wrapture/issues/72)).
+
 ## [0.4.0] - 2020-04-23
 ### Added
  - Inequality conditions for rules (less-than, less-than-equal, greater-than,

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    wrapture (0.4.0)
+    wrapture (0.4.1)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/wrapture/function_spec.rb
+++ b/lib/wrapture/function_spec.rb
@@ -185,12 +185,17 @@ module Wrapture
     # Calls return_expression on the return type of this function. +func_name+
     # is passed to return_expression if provided.
     def return_expression(func_name: name)
+      if @constructor || @destructor
+        return signature(func_name: func_name) 
+      end
+
       resolved_return.return_expression(self, func_name: func_name)
     end
 
-    # The signature of the function.
-    def signature
-      "#{name}( #{param_list} )"
+    # The signature of the function. +func_name+ can be used to override the
+    # function name if needed, for example if a class name qualifier is needed.
+    def signature(func_name: name)
+      "#{func_name}( #{param_list} )"
     end
 
     # Yields each line of the declaration of the function, including any

--- a/lib/wrapture/function_spec.rb
+++ b/lib/wrapture/function_spec.rb
@@ -203,11 +203,6 @@ module Wrapture
     def declaration
       doc.format_as_doxygen(max_line_length: 76) { |line| yield line }
 
-      if @constructor || @destructor
-        yield "#{signature};"
-        return
-      end
-
       modifier_prefix = if @spec['static']
                           'static '
                         elsif virtual?

--- a/lib/wrapture/function_spec.rb
+++ b/lib/wrapture/function_spec.rb
@@ -186,7 +186,7 @@ module Wrapture
     # is passed to return_expression if provided.
     def return_expression(func_name: name)
       if @constructor || @destructor
-        return signature(func_name: func_name) 
+        return signature(func_name: func_name)
       end
 
       resolved_return.return_expression(self, func_name: func_name)

--- a/lib/wrapture/function_spec.rb
+++ b/lib/wrapture/function_spec.rb
@@ -186,10 +186,10 @@ module Wrapture
     # is passed to return_expression if provided.
     def return_expression(func_name: name)
       if @constructor || @destructor
-        return signature(func_name: func_name)
+        signature(func_name: func_name)
+      else
+        resolved_return.return_expression(self, func_name: func_name)
       end
-
-      resolved_return.return_expression(self, func_name: func_name)
     end
 
     # The signature of the function. +func_name+ can be used to override the

--- a/lib/wrapture/version.rb
+++ b/lib/wrapture/version.rb
@@ -20,7 +20,7 @@
 
 module Wrapture
   # the current version of Wrapture
-  VERSION = '0.4.0'
+  VERSION = '0.4.1'
 
   # Returns true if the version of the spec is supported by this version of
   # Wrapture. Otherwise returns false.

--- a/test/test_class_spec.rb
+++ b/test/test_class_spec.rb
@@ -86,15 +86,15 @@ class ClassSpecTest < Minitest::Test
 
     member_regex = /^\s*#{class_name}\( int member/
     assert(file_contains_match(header_file, member_regex),
-           "the member constructor had a return type specified in the header")
+           'the member constructor had a return type specified in the header')
 
     spec_regex = /^\s*#{class_name}\( struct/
     assert(file_contains_match(header_file, spec_regex),
-           "the spec constructor had a return type specified in the header")
+           'the spec constructor had a return type specified in the header')
 
     destructor_regex = /^\s*~#{class_name}/
     assert(file_contains_match(header_file, destructor_regex),
-           "the destructor had a return type specified in the header")
+           'the destructor had a return type specified in the header')
 
     source_file = "#{class_name}.cpp"
     includes = get_include_list(source_file)
@@ -107,15 +107,15 @@ class ClassSpecTest < Minitest::Test
 
     member_regex = /^\s*#{class_name}::#{class_name}\( int member/
     assert(file_contains_match(source_file, member_regex),
-           "the member constructor had a return type specified when defined")
+           'the member constructor had a return type specified when defined')
 
     spec_regex = /^\s*#{class_name}::#{class_name}\( struct/
     assert(file_contains_match(source_file, spec_regex),
-           "the spec constructor had a return type specified when defined")
+           'the spec constructor had a return type specified when defined')
 
     destructor_regex = /^\s*#{class_name}::~#{class_name}/
     assert(file_contains_match(source_file, destructor_regex),
-           "the destructor had a return type specified when defined")
+           'the destructor had a return type specified when defined')
 
     wrapped_function = test_spec['constructors'][0]['wrapped-function']
     assert(file_contains_match(source_file, /= #{wrapped_function['name']}/))

--- a/test/test_class_spec.rb
+++ b/test/test_class_spec.rb
@@ -113,10 +113,11 @@ class ClassSpecTest < Minitest::Test
     assert(file_contains_match(source_file, spec_regex),
            "the spec constructor had a return type specified when defined")
 
-    destructor_regex = /^\s#{class_name}::~#{class_name}/
+    destructor_regex = /^\s*#{class_name}::~#{class_name}/
     assert(file_contains_match(source_file, destructor_regex),
            "the destructor had a return type specified when defined")
 
+    wrapped_function = test_spec['constructors'][0]['wrapped-function']
     assert(file_contains_match(source_file, /= #{wrapped_function['name']}/))
 
     File.delete(*generated_files)

--- a/test/test_class_spec.rb
+++ b/test/test_class_spec.rb
@@ -81,7 +81,22 @@ class ClassSpecTest < Minitest::Test
     classes = spec.generate_wrappers
     validate_wrapper_results(test_spec, classes)
 
-    source_file = "#{test_spec['name']}.cpp"
+    class_name = test_spec['name']
+    header_file = "#{class_name}.hpp"
+
+    member_regex = /^\s*#{class_name}\( int member/
+    assert(file_contains_match(header_file, member_regex),
+           "the member constructor had a return type specified in the header")
+
+    spec_regex = /^\s*#{class_name}\( struct/
+    assert(file_contains_match(header_file, spec_regex),
+           "the spec constructor had a return type specified in the header")
+
+    destructor_regex = /^\s*~#{class_name}/
+    assert(file_contains_match(header_file, destructor_regex),
+           "the destructor had a return type specified in the header")
+
+    source_file = "#{class_name}.cpp"
     includes = get_include_list(source_file)
     wrapped_function = test_spec['constructors'][0]['wrapped-function']
     assert_includes(includes, wrapped_function['includes'])
@@ -89,18 +104,17 @@ class ClassSpecTest < Minitest::Test
     forbidden = Wrapture::EQUIVALENT_STRUCT_KEYWORD
     assert(!file_contains_match(source_file, forbidden))
 
-    class_name = test_spec['name']
     member_regex = /^\s*#{class_name}::#{class_name}\( int member/
     assert(file_contains_match(source_file, member_regex),
-           "the member constructor had a return type specified")
+           "the member constructor had a return type specified when defined")
 
     spec_regex = /^\s*#{class_name}::#{class_name}\( struct/
     assert(file_contains_match(source_file, spec_regex),
-           "the spec constructor had a return type specified")
+           "the spec constructor had a return type specified when defined")
 
     destructor_regex = /^\s#{class_name}::~#{class_name}/
     assert(file_contains_match(source_file, destructor_regex),
-           "the destructor had a return type specified")
+           "the destructor had a return type specified when defined")
 
     assert(file_contains_match(source_file, /= #{wrapped_function['name']}/))
 

--- a/test/test_class_spec.rb
+++ b/test/test_class_spec.rb
@@ -89,6 +89,19 @@ class ClassSpecTest < Minitest::Test
     forbidden = Wrapture::EQUIVALENT_STRUCT_KEYWORD
     assert(!file_contains_match(source_file, forbidden))
 
+    class_name = test_spec['name']
+    member_regex = /^\s*#{class_name}::#{class_name}\( int member/
+    assert(file_contains_match(source_file, member_regex),
+           "the member constructor had a return type specified")
+
+    spec_regex = /^\s*#{class_name}::#{class_name}\( struct/
+    assert(file_contains_match(source_file, spec_regex),
+           "the spec constructor had a return type specified")
+
+    destructor_regex = /^\s#{class_name}::~#{class_name}/
+    assert(file_contains_match(source_file, destructor_regex),
+           "the destructor had a return type specified")
+
     assert(file_contains_match(source_file, /= #{wrapped_function['name']}/))
 
     File.delete(*classes)

--- a/test/test_class_spec.rb
+++ b/test/test_class_spec.rb
@@ -78,8 +78,8 @@ class ClassSpecTest < Minitest::Test
 
     spec = Wrapture::ClassSpec.new(test_spec)
 
-    classes = spec.generate_wrappers
-    validate_wrapper_results(test_spec, classes)
+    generated_files = spec.generate_wrappers
+    validate_wrapper_results(test_spec, generated_files)
 
     class_name = test_spec['name']
     header_file = "#{class_name}.hpp"
@@ -98,11 +98,12 @@ class ClassSpecTest < Minitest::Test
 
     source_file = "#{class_name}.cpp"
     includes = get_include_list(source_file)
-    wrapped_function = test_spec['constructors'][0]['wrapped-function']
-    assert_includes(includes, wrapped_function['includes'])
+    all_spec_includes(test_spec).each do |inc|
+      assert_includes(includes, inc)
+    end
 
     forbidden = Wrapture::EQUIVALENT_STRUCT_KEYWORD
-    assert(!file_contains_match(source_file, forbidden))
+    refute(file_contains_match(source_file, forbidden))
 
     member_regex = /^\s*#{class_name}::#{class_name}\( int member/
     assert(file_contains_match(source_file, member_regex),
@@ -118,7 +119,7 @@ class ClassSpecTest < Minitest::Test
 
     assert(file_contains_match(source_file, /= #{wrapped_function['name']}/))
 
-    File.delete(*classes)
+    File.delete(*generated_files)
   end
 
   def test_class_with_constant

--- a/wrapture.gemspec
+++ b/wrapture.gemspec
@@ -18,8 +18,8 @@
 
 Gem::Specification.new do |spec|
   spec.name        =  'wrapture'
-  spec.version     =  '0.4.0'
-  spec.date        =  '2020-04-23'
+  spec.version     =  '0.4.1'
+  spec.date        =  '2020-04-24'
   spec.summary     =  'wrap C in C++'
   spec.description =  'Wraps C code in C++.'
   spec.authors     =  ['Joel Anderson']


### PR DESCRIPTION
Return types were being erroneously provided in definitions of constructors and destructors of generated classes. Declarations were not affected, however. This patch corrects this behavior and adds tests for this behavior to prevent regression.

See issue #72 for more details on the bug.