### PR TITLE
drop ruby 2.3 support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+AllCops:
+  TargetRubyVersion: 2.4
+
 Lint/RaiseException:
   Enabled: true
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,9 @@
 AllCops:
   TargetRubyVersion: 2.4
 
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
+
 Lint/RaiseException:
   Enabled: true
 
@@ -18,6 +21,9 @@ Metrics/MethodLength:
 
 Style/Documentation:
   Enabled: false
+
+Style/ExponentialNotation:
+  Enabled: true
 
 Style/GuardClause:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,8 @@ matrix:
 #      gemfile: gemfiles/minimal.gemfile
 
 before_install:
-  - gem update --system --no-document
-  - gem install bundler --version 2.1.4 --no-document
+  - if [[ ! $TRAVIS_RUBY_VERSION =~ "rbx" ]]; then gem update --system --no-document; fi
+  - if [[ ! $TRAVIS_RUBY_VERSION =~ "rbx" ]]; then gem install bundler --version 2.1.4 --no-document; fi
 
 install:
   - bundle config set deployment 'true'

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,6 @@ rvm:
 matrix:
   allow_failures:
     - os: linux
-      rvm: rbx-3
-    - os: linux
       rvm: rbx-4
   include:
     - os: linux
@@ -32,7 +30,7 @@ matrix:
     - os: linux
       dist: trusty
       rvm: rbx-4
-#      gemfile: gemfiles/minimal.gemfile
+      gemfile: gemfiles/minimal.gemfile
 
 before_install:
   - if [[ ! $TRAVIS_RUBY_VERSION =~ "rbx" ]]; then gem update --system --no-document; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ os:
   - osx
 
 rvm:
-  - 2.3
   - 2.4
   - 2.5
   - 2.6
@@ -14,8 +13,6 @@ rvm:
 
 matrix:
   allow_failures:
-    - os: osx
-      rvm: 2.3
     - os: linux
       rvm: rbx-3
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,12 +31,8 @@ matrix:
           organization: "goatshriek-github"
     - os: linux
       dist: trusty
-      rvm: rbx-3
-      gemfile: gemfiles/minimal.gemfile
-    - os: linux
-      dist: trusty
       rvm: rbx-4
-      gemfile: gemfiles/minimal.gemfile
+#      gemfile: gemfiles/minimal.gemfile
 
 before_install:
   - gem update --system --no-document

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,10 @@ For a detailed look at the project's future, including planned features and bug
 fixes, check out the
 [roadmap](https://github.com/goatshriek/wrapture/blob/master/docs/roadmap.md).
 
+## [0.5.0] - 2020-04-25
+### Removed
+ - Ruby 2.3 is no longer supported.
+
 ## [0.4.1] - 2020-04-24
 ### Fixed
  - Constructor and destructor definitions no longer have a type of 'void'

--- a/Gemfile
+++ b/Gemfile
@@ -32,5 +32,10 @@ group :test do
   # minitest at or above 5.12 cause problems with rbx 4
   gem 'minitest', '>= 5.9', '< 5.12'
   gem 'rubocop', '>= 0.69', require: false
-  gem 'simplecov', '>= 0.16.1', '< 0.18', require: false
+  # using simplecov 0.18.2 causes the following problem with truffleruby:
+  # lib/simplecov.rb:236:in `floor': wrong number of arguments (given 1,
+  # expected 0) (ArgumentError)
+  # see the following travis build for an example:
+  # https://travis-ci.org/github/goatshriek/wrapture/jobs/679280059
+  gem 'simplecov', '>= 0.16.1', '<= 0.18.2', require: false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -32,10 +32,10 @@ group :test do
   # minitest at or above 5.12 cause problems with rbx 4
   gem 'minitest', '>= 5.9', '< 5.12'
   gem 'rubocop', '>= 0.69', require: false
-  # using simplecov 0.18.2 causes the following problem with truffleruby:
+  # using simplecov 0.18 causes the following problem with truffleruby:
   # lib/simplecov.rb:236:in `floor': wrong number of arguments (given 1,
   # expected 0) (ArgumentError)
   # see the following travis build for an example:
   # https://travis-ci.org/github/goatshriek/wrapture/jobs/679280059
-  gem 'simplecov', '>= 0.16.1', '<= 0.18.2', require: false
+  gem 'simplecov', '>= 0.16.1', '< 0.18', require: false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -31,8 +31,7 @@ group :test do
   gem 'codecov', '>= 0.1.14', require: false
   # minitest at or above 5.12 cause problems with rbx 4
   gem 'minitest', '>= 5.9', '< 5.12'
-  # rubocop at or above 0.82 requires ruby 2.4
-  gem 'rubocop', '>= 0.69', '< 0.82', require: false
+  gem 'rubocop', '>= 0.69', require: false
   # simplecov above 0.17.1 requires ruby 2.4
   gem 'simplecov', '>= 0.16.1', '<= 0.17.1', require: false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'json', '>= 1.8', '<= 2.3'
 
 group :development do
   gem 'rake', '>= 0.9.2'
-  gem 'rdoc', '>= 6.0', '< 6.2' # 6.2 requires >= ruby 2.4.0
+  gem 'rdoc', '>= 6.0'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,5 @@ group :test do
   # minitest at or above 5.12 cause problems with rbx 4
   gem 'minitest', '>= 5.9', '< 5.12'
   gem 'rubocop', '>= 0.69', require: false
-  # simplecov above 0.17.1 requires ruby 2.4
-  gem 'simplecov', '>= 0.16.1', '<= 0.17.1', require: false
+  gem 'simplecov', '>= 0.16.1', require: false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -37,5 +37,9 @@ group :test do
   # expected 0) (ArgumentError)
   # see the following travis build for an example:
   # https://travis-ci.org/github/goatshriek/wrapture/jobs/679280059
+  # this is due to a compatibility issue with truffleruby that will be fixed in
+  # version 20.1.0, and the upper limit can be removed after that
+  # see https://github.com/oracle/truffleruby/issues/1899 for a similar issue
+  # with another project
   gem 'simplecov', '>= 0.16.1', '< 0.18', require: false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -32,5 +32,5 @@ group :test do
   # minitest at or above 5.12 cause problems with rbx 4
   gem 'minitest', '>= 5.9', '< 5.12'
   gem 'rubocop', '>= 0.69', require: false
-  gem 'simplecov', '>= 0.16.1', require: false
+  gem 'simplecov', '>= 0.16.1', '< 0.18', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,10 +33,11 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
     ruby-progressbar (1.10.1)
-    simplecov (0.18.5)
+    simplecov (0.17.1)
       docile (~> 1.1)
-      simplecov-html (~> 0.11)
-    simplecov-html (0.12.2)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     unicode-display_width (1.7.0)
     url (0.3.2)
 
@@ -52,7 +53,7 @@ DEPENDENCIES
   rake (>= 0.9.2)
   rdoc (>= 6.0)
   rubocop (>= 0.69)
-  simplecov (>= 0.16.1)
+  simplecov (>= 0.16.1, < 0.18)
   wrapture!
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,11 +33,10 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
     ruby-progressbar (1.10.1)
-    simplecov (0.17.1)
+    simplecov (0.18.2)
       docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
+      simplecov-html (~> 0.11)
+    simplecov-html (0.12.2)
     unicode-display_width (1.7.0)
     url (0.3.2)
 
@@ -53,7 +52,7 @@ DEPENDENCIES
   rake (>= 0.9.2)
   rdoc (>= 6.0)
   rubocop (>= 0.69)
-  simplecov (>= 0.16.1, < 0.18)
+  simplecov (>= 0.16.1, <= 0.18.2)
   wrapture!
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    wrapture (0.4.0)
+    wrapture (0.5.0)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,10 +33,11 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
     ruby-progressbar (1.10.1)
-    simplecov (0.18.2)
+    simplecov (0.17.1)
       docile (~> 1.1)
-      simplecov-html (~> 0.11)
-    simplecov-html (0.12.2)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     unicode-display_width (1.7.0)
     url (0.3.2)
 
@@ -52,7 +53,7 @@ DEPENDENCIES
   rake (>= 0.9.2)
   rdoc (>= 6.0)
   rubocop (>= 0.69)
-  simplecov (>= 0.16.1, <= 0.18.2)
+  simplecov (>= 0.16.1, < 0.18)
   wrapture!
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,11 +33,10 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
     ruby-progressbar (1.10.1)
-    simplecov (0.17.1)
+    simplecov (0.18.5)
       docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
+      simplecov-html (~> 0.11)
+    simplecov-html (0.12.2)
     unicode-display_width (1.7.0)
     url (0.3.2)
 
@@ -53,7 +52,7 @@ DEPENDENCIES
   rake (>= 0.9.2)
   rdoc (>= 6.0)
   rubocop (>= 0.69)
-  simplecov (>= 0.16.1, <= 0.17.1)
+  simplecov (>= 0.16.1)
   wrapture!
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GEM
       ast (~> 2.4.0)
     rainbow (3.0.0)
     rake (13.0.1)
-    rdoc (6.1.2)
+    rdoc (6.2.1)
     rexml (3.2.4)
     rubocop (0.82.0)
       jaro_winkler (~> 1.5.1)
@@ -51,7 +51,7 @@ DEPENDENCIES
   json (>= 1.8, <= 2.3)
   minitest (>= 5.9, < 5.12)
   rake (>= 0.9.2)
-  rdoc (>= 6.0, < 6.2)
+  rdoc (>= 6.0)
   rubocop (>= 0.69)
   simplecov (>= 0.16.1, <= 0.17.1)
   wrapture!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,4 +54,4 @@ DEPENDENCIES
   wrapture!
 
 BUNDLED WITH
-   2.1.2
+   2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GEM
     rake (13.0.1)
     rdoc (6.1.2)
     rexml (3.2.4)
-    rubocop (0.81.0)
+    rubocop (0.82.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.7.0.1)
@@ -49,7 +49,7 @@ DEPENDENCIES
   minitest (>= 5.9, < 5.12)
   rake (>= 0.9.2)
   rdoc (>= 6.0, < 6.2)
-  rubocop (>= 0.69, < 0.82)
+  rubocop (>= 0.69)
   simplecov (>= 0.16.1, <= 0.17.1)
   wrapture!
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,9 @@ GEM
       url
     docile (1.3.2)
     jaro_winkler (1.5.4)
+    jaro_winkler (1.5.4-java)
     json (2.3.0)
+    json (2.3.0-java)
     minitest (5.11.3)
     parallel (1.19.1)
     parser (2.7.1.1)
@@ -40,6 +42,7 @@ GEM
     url (0.3.2)
 
 PLATFORMS
+  java
   ruby
 
 DEPENDENCIES

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -35,10 +35,6 @@ timing is often left out to prevent folks from feeling cheated if something
 takes longer than expected.
 
 ## 0.5.0
- * [REMOVE] **Support for Ruby 2.3**
-   Several gems in use (rubocop and simplecov, for example) require Ruby 2.4 for
-   their newest versions. Dropping support for Ruby 2.3 will allow the project
-   to make use of features in the latest versions, for example new rubocop cops.
  * [ADD] **Python class generation**
    Python is a commonly used language in a variety of applications, and
    extension of C code into it is estimated to be a valuable feature.

--- a/lib/wrapture/version.rb
+++ b/lib/wrapture/version.rb
@@ -20,7 +20,7 @@
 
 module Wrapture
   # the current version of Wrapture
-  VERSION = '0.4.0'
+  VERSION = '0.5.0'
 
   # Returns true if the version of the spec is supported by this version of
   # Wrapture. Otherwise returns false.

--- a/test/test_version.rb
+++ b/test/test_version.rb
@@ -6,6 +6,20 @@ require 'minitest/autorun'
 require 'wrapture'
 
 class VersionTest < Minitest::Test
+  def test_gemspec_date
+    spec = Gem::Specification.load('wrapture.gemspec')
+
+    date_regex = /^## \[(\d+\.\d+\.\d+)\] - (\d{4}-\d{2}-\d{2})/
+    File.open('ChangeLog.md').each do |line|
+      date_regex.match(line) do |match_data|
+        if match_data[1] == spec.version.to_s
+          assert_equal(match_data[2], spec.date.strftime('%Y-%m-%d'),
+                       'the changelog date and gem date do not match')
+        end
+      end
+    end
+  end
+
   def test_gemspec_version
     spec = Gem::Specification.load('wrapture.gemspec')
     spec_version = spec.version.to_s

--- a/wrapture.gemspec
+++ b/wrapture.gemspec
@@ -24,11 +24,11 @@ Gem::Specification.new do |spec|
   spec.description =  'Wraps C code in C++.'
   spec.authors     =  ['Joel Anderson']
   spec.email       =  'joelanderson333@gmail.com'
-  spec.files       =  Dir.glob('{lib,bin}/**/*').reject do |file|
-    File.directory? file
+  spec.files       =  Dir.glob('{lib,bin}/**/*').reject do |file_or_dir|
+    File.directory?(file_or_dir)
   end
   spec.executables << 'wrapture'
-  spec.homepage    =  'http://rubygems.org/gems/wrapture'
+  spec.homepage    =  'https://goatshriek.github.io/wrapture/'
   spec.license     =  'Apache-2.0'
 
   spec.required_ruby_version = '>= 2.4'

--- a/wrapture.gemspec
+++ b/wrapture.gemspec
@@ -18,7 +18,7 @@
 
 Gem::Specification.new do |spec|
   spec.name        =  'wrapture'
-  spec.version     =  '0.4.0'
+  spec.version     =  '0.5.0'
   spec.date        =  '2020-04-23'
   spec.summary     =  'wrap C in C++'
   spec.description =  'Wraps C code in C++.'
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.homepage    =  'http://rubygems.org/gems/wrapture'
   spec.license     =  'Apache-2.0'
 
-  spec.required_ruby_version = '>= 2.3'
+  spec.required_ruby_version = '>= 2.4'
   spec.add_development_dependency 'bundler', '>= 1.6.4', '< 2.2'
 
   if spec.respond_to?(:metadata)

--- a/wrapture.gemspec
+++ b/wrapture.gemspec
@@ -19,7 +19,7 @@
 Gem::Specification.new do |spec|
   spec.name        =  'wrapture'
   spec.version     =  '0.5.0'
-  spec.date        =  '2020-04-24'
+  spec.date        =  '2020-04-25'
   spec.summary     =  'wrap C in C++'
   spec.description =  'Wraps C code in C++.'
   spec.authors     =  ['Joel Anderson']


### PR DESCRIPTION
Several gems in use (rubocop and simplecov, for example) require Ruby 2.4 for their newest versions. Dropping support for Ruby 2.3 allows use of features in the latest versions, for example new rubocop cops.

Simplecov has been kept below 0.18 due to compatibility issues with truffleruby 20.0.0. Once truffleruby 20.1.0 is available on Travis CI, the constraint will be removed. See https://github.com/oracle/truffleruby/issues/1899 for the relevant issue.