### PR TITLE
fix function pointer return errors

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,9 +9,9 @@ For a detailed look at the project's future, including planned features and bug
 fixes, check out the
 [roadmap](https://github.com/goatshriek/wrapture/blob/master/docs/roadmap.md).
 
-## [0.4.2] - 2020-05-06
+## [0.4.2] - 2020-05-09
 ### Fixed
- - Functions that return function pointers now return the type correctly instead
+ - Functions that return function pointers now cast the return correctly instead
    of containing non-valid code
    ([issue #76](https://github.com/goatshriek/wrapture/issues/76)).
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,12 @@ For a detailed look at the project's future, including planned features and bug
 fixes, check out the
 [roadmap](https://github.com/goatshriek/wrapture/blob/master/docs/roadmap.md).
 
+## [0.4.2] - 2020-05-06
+### Fixed
+ - Functions that return function pointers now return the type correctly instead
+   of containing non-valid code
+   ([issue #76](https://github.com/goatshriek/wrapture/issues/76)).
+
 ## [0.4.1] - 2020-04-24
 ### Fixed
  - Constructor and destructor definitions no longer have a type of 'void'

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -35,12 +35,6 @@ timing is often left out to prevent folks from feeling cheated if something
 takes longer than expected.
 
 ## 0.4.2
- * [FIX] **Functions returning function pointers are invalid**
-   Definitions of functions that return a function pointer are incorrectly
-   generated, dumping the contents of the TypeSpec hash directly into the code.
-   For more details, see
-   [issue #76](https://github.com/goatshriek/wrapture/issues/76) on the project
-   Github site.
  * [FIX] **Return value variable declarations incorrect when using keywords**
    Return values are incorrectly typed using the wrapture keyword when the
    return type is given as one. This is most apparent in constructor

--- a/lib/wrapture/function_spec.rb
+++ b/lib/wrapture/function_spec.rb
@@ -321,7 +321,7 @@ module Wrapture
       elsif @spec['return']['overloaded']
         "new#{@spec['return']['type'].chomp('*').strip} ( #{value} )"
       else
-        "#{@spec['return']['type']} ( #{value} )"
+        resolved_return.cast_expression(value)
       end
     end
 

--- a/lib/wrapture/type_spec.rb
+++ b/lib/wrapture/type_spec.rb
@@ -59,6 +59,13 @@ module Wrapture
       name.delete('*&').strip
     end
 
+    # An expression casting the result of a given expression into this type.
+    #
+    # Added in release 0.4.2.
+    def cast_expression(expression)
+      "( #{variable} )( #{expression} )"
+    end
+
     # True if this type is an equivalent struct pointer reference.
     def equivalent_pointer?
       name == EQUIVALENT_POINTER_KEYWORD

--- a/test/test_function_spec.rb
+++ b/test/test_function_spec.rb
@@ -102,6 +102,8 @@ class FunctionSpecTest < Minitest::Test
 
     lines = spec.definition(&block_collector)
     assert(lines.any? { |line| line.include?(expected_definition) })
+    refute(lines.any? { |line| line.include?('=>') },
+           'a rocket operator was found in the output code')
   end
 
   def test_future_spec_version

--- a/wrapture.gemspec
+++ b/wrapture.gemspec
@@ -19,7 +19,7 @@
 Gem::Specification.new do |spec|
   spec.name        =  'wrapture'
   spec.version     =  '0.4.2'
-  spec.date        =  '2020-05-06'
+  spec.date        =  '2020-05-09'
   spec.summary     =  'wrap C in C++'
   spec.description =  'Wraps C code in C++.'
   spec.authors     =  ['Joel Anderson']


### PR DESCRIPTION
Definitions of functions that return a function themselves were incorrectly generated, dumping the contents of the TypeSpec hash directly into the code. This is corrected by adding a new function (TypeSpec.cast_expression) and using it in the function definition generation.

See issue #76 for more details on the bug.