### PR TITLE
fix return variable declarations

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,6 +14,10 @@ fixes, check out the
  - Functions that return function pointers now cast the return correctly instead
    of containing non-valid code
    ([issue #76](https://github.com/goatshriek/wrapture/issues/76)).
+ - Return value types are now valid types when they are given using a special
+   keyword in the spec, such as `equivalent-struct-pointer`. The types are now
+   resolved based on the keyword if one is used
+   ([issue #77](https://github.com/goatshriek/wrapture/issues/77)).
 
 ## [0.4.1] - 2020-04-24
 ### Fixed

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -35,13 +35,6 @@ timing is often left out to prevent folks from feeling cheated if something
 takes longer than expected.
 
 ## 0.4.2
- * [FIX] **Return value variable declarations incorrect when using keywords**
-   Return values are incorrectly typed using the wrapture keyword when the
-   return type is given as one. This is most apparent in constructor
-   definitions, which specify the return type so that the equivalent struct
-   pointer can be set appropriately. For more details, see
-   [issue #77](https://github.com/goatshriek/wrapture/issues/77) on the project
-   Github site.
  * [FIX] **Exception actions with no parameters cannot be taken**
    If a `throw-exception` action is defined with a constructor that does not
    take any parameters, then an Exception is raised when the take method is

--- a/lib/wrapture/function_spec.rb
+++ b/lib/wrapture/function_spec.rb
@@ -320,7 +320,7 @@ module Wrapture
 
     # The function to use to create the return value of the function.
     def return_cast(value)
-      if @spec['return']['type'] == @wrapped.return_val_type
+      if @return_type == @wrapped.return_val_type
         value
       elsif @spec['return']['overloaded']
         "new#{@spec['return']['type'].chomp('*').strip} ( #{value} )"

--- a/lib/wrapture/function_spec.rb
+++ b/lib/wrapture/function_spec.rb
@@ -311,7 +311,11 @@ module Wrapture
     # Yields a declaration of each local variable used by the function.
     def locals
       yield 'va_list variadic_args;' if variadic?
-      yield "#{@wrapped.return_val_type} return_val;" if @wrapped.error_check?
+
+      if @wrapped.error_check?
+        wrapped_type = resolve_type(@wrapped.return_val_type)
+        yield "#{wrapped_type.variable('return_val')};"
+      end
     end
 
     # The function to use to create the return value of the function.

--- a/lib/wrapture/type_spec.rb
+++ b/lib/wrapture/type_spec.rb
@@ -54,18 +54,12 @@ module Wrapture
       @spec = TypeSpec.normalize_spec_hash(actual_spec)
     end
 
-    # Compares this TypeSpec with either another TypeSpec, or with a String
-    # holding the name of a type.
+    # Compares this TypeSpec with +other+. Comparison happens by converting each
+    # object to a string using to_s and comparing.
     #
     # Added in release 0.4.2.
-    def ==(type)
-      if type.is_a?(TypeSpec)
-        name == type.name
-      elsif type.is_a?(String)
-        name == type
-      else
-        false
-      end
+    def ==(other)
+      to_s == other.to_s
     end
 
     # The name of this type with all special characters removed.
@@ -151,6 +145,13 @@ module Wrapture
     # True if this type is a reference to a class instance.
     def self?
       name == SELF_REFERENCE_KEYWORD
+    end
+
+    # Gives a string representation of this type (its name).
+    #
+    # Added in release 0.4.2.
+    def to_s
+      name
     end
 
     # A string with a declaration of a variable named +var_name+ of this type.

--- a/lib/wrapture/type_spec.rb
+++ b/lib/wrapture/type_spec.rb
@@ -54,6 +54,20 @@ module Wrapture
       @spec = TypeSpec.normalize_spec_hash(actual_spec)
     end
 
+    # Compares this TypeSpec with either another TypeSpec, or with a String
+    # holding the name of a type.
+    #
+    # Added in release 0.4.2.
+    def ==(type)
+      if type.is_a?(TypeSpec)
+        name == type.name
+      elsif type.is_a?(String)
+        name == type
+      else
+        false
+      end
+    end
+
     # The name of this type with all special characters removed.
     def base
       name.delete('*&').strip

--- a/lib/wrapture/wrapped_function_spec.rb
+++ b/lib/wrapture/wrapped_function_spec.rb
@@ -111,9 +111,11 @@ module Wrapture
       includes
     end
 
-    # A string with the type of the return value.
+    # A TypeSpec describing the type of the return value.
+    #
+    # Changed in 0.4.2 to return a TypeSpec instead of a String.
     def return_val_type
-      @spec['return']['type']
+      TypeSpec.new(@spec['return']['type'])
     end
   end
 end

--- a/lib/wrapture/wrapped_function_spec.rb
+++ b/lib/wrapture/wrapped_function_spec.rb
@@ -113,7 +113,7 @@ module Wrapture
 
     # A TypeSpec describing the type of the return value.
     #
-    # Changed in 0.4.2 to return a TypeSpec instead of a String.
+    # Changed in release 0.4.2 to return a TypeSpec instead of a String.
     def return_val_type
       TypeSpec.new(@spec['return']['type'])
     end

--- a/test/fixtures/class_with_return_val_in_constructor.yml
+++ b/test/fixtures/class_with_return_val_in_constructor.yml
@@ -1,0 +1,28 @@
+name: "ClassWithReturnActionInConstructor"
+namespace: "wrapture_test"
+equivalent_struct:
+  name: "irrelevant"
+constructors:
+  - wrapped-function:
+      name: "wrapped_constructor"
+      params:
+        - name: "name"
+          type: "const char *"
+      return:
+        type: "equivalent-struct-pointer"
+      error-check:
+        rules:
+          - left-expression: "return-value"
+            condition: "equals"
+            right-expression: "NULL"
+        error-action:
+          name: "throw-exception"
+          constructor:
+            name: "throwMyException"
+            params:
+              - value: "name"
+destructor:
+  wrapped-function:
+    name: "wrapped_destructor"
+    params:
+      - value: "equivalent-struct-pointer"

--- a/test/fixtures/class_with_return_val_in_constructor.yml
+++ b/test/fixtures/class_with_return_val_in_constructor.yml
@@ -1,6 +1,6 @@
 name: "ClassWithReturnActionInConstructor"
 namespace: "wrapture_test"
-equivalent_struct:
+equivalent-struct:
   name: "irrelevant"
 constructors:
   - wrapped-function:

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -95,6 +95,17 @@ def get_include_list(filename)
   includes
 end
 
+def refute_keywords_found(filename)
+  File.open(filename) do |file|
+    file.each do |line|
+      Wrapture::KEYWORDS.each do |keyword|
+        refute(line.include?(keyword),
+               "#{filename} had keyword '#{keyword}' on line #{file.lineno}")
+      end
+    end
+  end
+end
+
 def validate_class_wrapper(spec, file_list)
   refute_nil(file_list)
   refute_empty(file_list)
@@ -119,6 +130,7 @@ def validate_declaration_file(spec)
   validate_indentation filename
   validate_members(spec, filename)
   validate_namespace(spec, filename)
+  refute_keywords_found(filename)
 end
 
 def validate_definition_file(spec)
@@ -144,6 +156,7 @@ def validate_definition_file(spec)
 
   validate_indentation filename
   validate_namespace(spec, filename)
+  refute_keywords_found(filename)
 end
 
 def validate_indentation(filename)

--- a/test/test_class_spec.rb
+++ b/test/test_class_spec.rb
@@ -43,6 +43,17 @@ class ClassSpecTest < Minitest::Test
     refute_nil normalized_spec
   end
 
+  def test_return_val_in_constructor
+    test_spec = load_fixture('class_with_return_val_in_constructor')
+
+    spec = Wrapture::ClassSpec.new(test_spec)
+    generated_files = spec.generate_wrappers
+
+    validate_wrapper_results(test_spec, generated_files)
+
+    File.delete(*generated_files)
+  end
+
   def test_future_spec_version
     test_spec = load_fixture('future_version_class')
 

--- a/test/test_function_spec.rb
+++ b/test/test_function_spec.rb
@@ -119,7 +119,7 @@ class FunctionSpecTest < Minitest::Test
 
     spec = Wrapture::FunctionSpec.new(test_spec)
 
-    call = "( const char * )( #{test_spec['wrapped-function']['name']}"
+    call = test_spec['wrapped-function']['name']
     spec.definition do |line|
       code = line.strip
 

--- a/test/test_function_spec.rb
+++ b/test/test_function_spec.rb
@@ -119,7 +119,7 @@ class FunctionSpecTest < Minitest::Test
 
     spec = Wrapture::FunctionSpec.new(test_spec)
 
-    call = test_spec['wrapped-function']['name']
+    call = "( const char * )( #{test_spec['wrapped-function']['name']}"
     spec.definition do |line|
       code = line.strip
 

--- a/test/test_type_spec.rb
+++ b/test/test_type_spec.rb
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# frozen_string_literal: true
+
+# Copyright 2020 Joel E. Anderson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'helper'
+
+require 'fixture'
+require 'minitest/autorun'
+require 'wrapture'
+
+class TypeSpecTest < Minitest::Test
+  def test_equality_with_int
+    refute(Wrapture::TypeSpec.new('conswt char *') == 3)
+  end
+
+  def test_equality_with_string
+    assert(Wrapture::TypeSpec.new('const char *') == 'const char *')
+  end
+end


### PR DESCRIPTION
Return values were incorrectly typed using a wrapture keyword when the return type is given as one, for example as `equivalent-struct-pointer`. Now they are correctly resolved in the context of the function.

This fixes #77, which can be referenced for more details.