### PR TITLE
add missing keyword

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -18,6 +18,8 @@ fixes, check out the
    keyword in the spec, such as `equivalent-struct-pointer`. The types are now
    resolved based on the keyword if one is used
    ([issue #77](https://github.com/goatshriek/wrapture/issues/77)).
+ - The list `Wrapture::KEYWORDS` now contains the value in
+   `Wrapture::SELF_REFERENCE_KEYWORD`.
 
 ## [0.4.1] - 2020-04-24
 ### Fixed

--- a/lib/wrapture/constants.rb
+++ b/lib/wrapture/constants.rb
@@ -36,5 +36,6 @@ module Wrapture
 
   # A list of all keywords.
   KEYWORDS = [EQUIVALENT_STRUCT_KEYWORD, EQUIVALENT_POINTER_KEYWORD,
-              RETURN_VALUE_KEYWORD, TEMPLATE_USE_KEYWORD].freeze
+              SELF_REFERENCE_KEYWORD, RETURN_VALUE_KEYWORD,
+              TEMPLATE_USE_KEYWORD].freeze
 end

--- a/test/test_constants.rb
+++ b/test/test_constants.rb
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# frozen_string_literal: true
+
+# Copyright 2020 Joel E. Anderson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'helper'
+
+require 'fixture'
+require 'minitest/autorun'
+require 'wrapture'
+
+class ConstantsTest < Minitest::Test
+  def test_keywords_array
+    Wrapture.constants.select { |sym| sym.end_with?("KEYWORD") }.each do |word|
+      assert_includes(Wrapture::KEYWORDS, Wrapture.const_get(word))
+    end
+  end
+end

--- a/test/test_constants.rb
+++ b/test/test_constants.rb
@@ -24,7 +24,8 @@ require 'wrapture'
 
 class ConstantsTest < Minitest::Test
   def test_keywords_array
-    Wrapture.constants.select { |sym| sym.end_with?("KEYWORD") }.each do |word|
+    keywords = Wrapture.constants.select { |sym| sym.to_s.end_with?("KEYWORD") }
+    keywords.each do |word|
       assert_includes(Wrapture::KEYWORDS, Wrapture.const_get(word))
     end
   end

--- a/test/test_constants.rb
+++ b/test/test_constants.rb
@@ -24,7 +24,7 @@ require 'wrapture'
 
 class ConstantsTest < Minitest::Test
   def test_keywords_array
-    keywords = Wrapture.constants.select { |sym| sym.to_s.end_with?("KEYWORD") }
+    keywords = Wrapture.constants.select { |sym| sym.to_s.end_with?('KEYWORD') }
     keywords.each do |word|
       assert_includes(Wrapture::KEYWORDS, Wrapture.const_get(word))
     end


### PR DESCRIPTION
`Wrapture::KEYWORDS` was missing the `Wrapture::SELF_REFERENCE_KEYWORD` value. The missing value is added, as well as a test for any missing keywords to prevent regression.