### PR TITLE
fix actions with no params

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,9 @@ fixes, check out the
    ([issue #77](https://github.com/goatshriek/wrapture/issues/77)).
  - The list `Wrapture::KEYWORDS` now contains the value in
    `Wrapture::SELF_REFERENCE_KEYWORD`.
+ - `throw-exception` actions with no parameters for the constructor no longer
+   cause an error
+   ([issue #78](https://github.com/goatshriek/wrapture/issues/78)).
 
 ## [0.4.1] - 2020-04-24
 ### Fixed

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -34,14 +34,6 @@ project team is not currently big enough to realistically make any promises, so
 timing is often left out to prevent folks from feeling cheated if something
 takes longer than expected.
 
-## 0.4.2
- * [FIX] **Exception actions with no parameters cannot be taken**
-   If a `throw-exception` action is defined with a constructor that does not
-   take any parameters, then an Exception is raised when the take method is
-   called on the ActionSpec instance. For more details, see
-   [issue #78](https://github.com/goatshriek/wrapture/issues/78) on the project
-   Github site.
-
 ## 0.5.0
  * [REMOVE] **Support for Ruby 2.3**
    Several gems in use (rubocop and simplecov, for example) require Ruby 2.4 for

--- a/lib/wrapture/action_spec.rb
+++ b/lib/wrapture/action_spec.rb
@@ -40,8 +40,8 @@ module Wrapture
         raise(InvalidSpecKey, extra_msg)
       end
 
-      includes = Wrapture.normalize_includes(spec['constructor']['includes'])
-      normalized['constructor']['includes'] = includes
+      func_spec = WrappedFunctionSpec.normalize_spec_hash(spec['constructor'])
+      normalized['constructor'] = func_spec
 
       normalized
     end

--- a/test/fixtures/exception_action_without_params.yml
+++ b/test/fixtures/exception_action_without_params.yml
@@ -1,0 +1,3 @@
+name: "throw-exception"
+constructor:
+  name: "NoParamException"

--- a/test/test_action_spec.rb
+++ b/test/test_action_spec.rb
@@ -36,6 +36,14 @@ class ActionSpecTest < Minitest::Test
     assert(action.include?('throw NewCustomException'))
   end
 
+  def test_exception_without_params
+    test_spec = load_fixture('exception_action_without_params')
+
+    spec = Wrapture::ActionSpec.new(test_spec)
+
+    assert_match(/#{test_spec['constructor']['name']}\(\s*\)/, spec.take)
+  end
+
   def test_extra_key
     test_spec = load_fixture('extra_key_action')
 


### PR DESCRIPTION
If a `throw-exception` action was defined with a constructor that did not have any parameters, then an error was raised when the `take` method was called on the ActionSpec instance. This has been fixed by using `WrappedFunctionSpec::normalize_spec_hash` to normalize the spec.

This fixes #78, which can be referenced for more details.