### PR TITLE
fix return value usage in constructors

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,7 +9,7 @@ For a detailed look at the project's future, including planned features and bug
 fixes, check out the
 [roadmap](https://github.com/goatshriek/wrapture/blob/master/docs/roadmap.md).
 
-## [0.4.2] - 2020-05-09
+## [0.4.2] - 2020-05-10
 ### Fixed
  - Functions that return function pointers now cast the return correctly instead
    of containing non-valid code
@@ -23,6 +23,9 @@ fixes, check out the
  - `throw-exception` actions with no parameters for the constructor no longer
    cause an error
    ([issue #78](https://github.com/goatshriek/wrapture/issues/78)).
+ - Return values are correctly switched to the equivalent struct in
+   constructors instead of using `return_val`, which was not actually set
+   ([issue #84](https://github.com/goatshriek/wrapture/issues/84)).
 
 ## [0.4.1] - 2020-04-24
 ### Fixed

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,7 +9,7 @@ For a detailed look at the project's future, including planned features and bug
 fixes, check out the
 [roadmap](https://github.com/goatshriek/wrapture/blob/master/docs/roadmap.md).
 
-## [0.4.2] - 2020-05-10
+## [0.4.2] - 2020-05-11
 ### Fixed
  - Functions that return function pointers now cast the return correctly instead
    of containing non-valid code

--- a/lib/wrapture/function_spec.rb
+++ b/lib/wrapture/function_spec.rb
@@ -285,6 +285,11 @@ module Wrapture
 
     private
 
+    # The resolved type of the return type.
+    def resolved_return
+      @return_type.resolve(self)
+    end
+
     # True if the provided wrapped param spec can be cast to when used in this
     # function.
     def castable?(wrapped_param)
@@ -313,11 +318,6 @@ module Wrapture
         wrapped_type = resolve_type(@wrapped.return_val_type)
         yield "#{wrapped_type.variable('return_val')};"
       end
-    end
-
-    # The resolved type of the return type.
-    def resolved_return
-      @return_type.resolve(self)
     end
 
     # The function to use to create the return value of the function.

--- a/lib/wrapture/rule_spec.rb
+++ b/lib/wrapture/rule_spec.rb
@@ -95,5 +95,18 @@ module Wrapture
         "#{left} #{condition} #{right}".sub(RETURN_VALUE_KEYWORD, return_val)
       end
     end
+
+    # True if this rule requires a return value. This is equivalent to checking
+    # for the presence of RETURN_VALUE_KEYWORD in any of the expressions.
+    #
+    # This method was added in release 0.4.2.
+    def use_return?
+      if @spec['type'] == 'struct-member'
+        @spec['value'] == RETURN_VALUE_KEYWORD
+      else
+        [@spec['left-expression'],
+         @spec['right-expression']].include?(RETURN_VALUE_KEYWORD)
+      end
+    end
   end
 end

--- a/lib/wrapture/rule_spec.rb
+++ b/lib/wrapture/rule_spec.rb
@@ -64,14 +64,23 @@ module Wrapture
       normalized
     end
 
-    # Creates a rule spec based on the provided spec.
+    # Creates a rule spec based on the provided spec. Rules may be one of a
+    # number of different varieties.
     #
-    # The hash must have the following keys:
+    # Available conditions are available in the RuleSpec::CONDITIONS map, with
+    # the mapped values being the operate each one translates to.
+    #
+    # For a rule that checks a struct member against a given value (a
+    # +struct-member+ rule):
     # member-name:: the name of the struct member the rule applies to
-    # condition:: the condition this rule uses (supported values are keys in the
-    #             RuleSpec::CONDITIONS map, with the mapped values being the
-    #             operator they translate to)
+    # condition:: the condition this rule uses
     # value:: the value to use in the condition check
+    #
+    # For a rule that compares two expressions against one another (an
+    # +expression+ rule):
+    # left-expression:: the left expression in the comparison
+    # condition:: the condition this rule uses
+    # right-expression:: the right expression in the comparison
     def initialize(spec)
       @spec = RuleSpec.normalize_spec_hash(spec)
     end
@@ -101,12 +110,9 @@ module Wrapture
     #
     # This method was added in release 0.4.2.
     def use_return?
-      if @spec['type'] == 'struct-member'
-        @spec['value'] == RETURN_VALUE_KEYWORD
-      else
+      @spec['type'] == 'expression' &&
         [@spec['left-expression'],
          @spec['right-expression']].include?(RETURN_VALUE_KEYWORD)
-      end
     end
   end
 end

--- a/lib/wrapture/rule_spec.rb
+++ b/lib/wrapture/rule_spec.rb
@@ -77,7 +77,14 @@ module Wrapture
     end
 
     # A string containing a check for a struct of the given name for this rule.
-    def check(variable: nil)
+    #
+    # +variable+ can be provided to provide the variable holding a struct
+    # pointer for +struct-member+ rules.
+    #
+    # +return_val+ is used as the replacement for a return value signified by
+    # the use of RETURN_VALUE_KEYWORD in the spec. If not specified it defaults
+    # to +'return_val'+.
+    def check(variable: nil, return_val: 'return_val')
       condition = RuleSpec::CONDITIONS[@spec['condition']]
 
       if @spec['type'] == 'struct-member'
@@ -85,7 +92,7 @@ module Wrapture
       else
         left = @spec['left-expression']
         right = @spec['right-expression']
-        "#{left} #{condition} #{right}".sub(RETURN_VALUE_KEYWORD, 'return_val')
+        "#{left} #{condition} #{right}".sub(RETURN_VALUE_KEYWORD, return_val)
       end
     end
   end

--- a/lib/wrapture/rule_spec.rb
+++ b/lib/wrapture/rule_spec.rb
@@ -83,7 +83,7 @@ module Wrapture
     #
     # +return_val+ is used as the replacement for a return value signified by
     # the use of RETURN_VALUE_KEYWORD in the spec. If not specified it defaults
-    # to +'return_val'+.
+    # to +'return_val'+. This parameter was added in release 0.4.2.
     def check(variable: nil, return_val: 'return_val')
       condition = RuleSpec::CONDITIONS[@spec['condition']]
 

--- a/lib/wrapture/wrapped_function_spec.rb
+++ b/lib/wrapture/wrapped_function_spec.rb
@@ -88,10 +88,14 @@ module Wrapture
     # Yields each line of the error check and any actions taken for this wrapped
     # function. If this function does not have any error check defined, then
     # this function returns without yielding anything.
-    def error_check
+    #
+    # +return_val+ is used as the replacement for a return value signified by
+    # the use of RETURN_VALUE_KEYWORD in the spec. If not specified it defaults
+    # to +'return_val'+. This parameter was added in release 0.4.2.
+    def error_check(return_val: 'return_val')
       return if @error_rules.empty?
 
-      checks = @error_rules.map(&:check)
+      checks = @error_rules.map { |rule| rule.check(return_val: return_val) }
       yield "if( #{checks.join(' && ')} ){"
       yield "  #{@error_action.take};"
       yield '}'
@@ -116,6 +120,15 @@ module Wrapture
     # Changed in release 0.4.2 to return a TypeSpec instead of a String.
     def return_val_type
       TypeSpec.new(@spec['return']['type'])
+    end
+
+    # True if calling this wrapped function needs to save/use the return value
+    # for error checking. This is equivalent to checking all error rules for the
+    # use of RETURN_VALUE_KEYWORD.
+    #
+    # This method was added in release 0.4.2.
+    def use_return?
+      @error_rules.any?(&:use_return?)
     end
   end
 end

--- a/test/test_class_spec.rb
+++ b/test/test_class_spec.rb
@@ -54,6 +54,8 @@ class ClassSpecTest < Minitest::Test
     source_file = "#{test_spec['name']}.cpp"
     assert(file_contains_match(source_file, 'this->equivalent == NULL'),
            'no error check against the equivalent struct was found')
+    refute(file_contains_match(source_file, 'return_val'),
+           'a return value variable was still generated')
 
     File.delete(*generated_files)
   end

--- a/test/test_class_spec.rb
+++ b/test/test_class_spec.rb
@@ -51,6 +51,10 @@ class ClassSpecTest < Minitest::Test
 
     validate_wrapper_results(test_spec, generated_files)
 
+    source_file = "#{test_spec['name']}.cpp"
+    assert(file_contains_match(source_file, 'this->equivalent == NULL'),
+           'no error check against the equivalent struct was found')
+
     File.delete(*generated_files)
   end
 

--- a/wrapture.gemspec
+++ b/wrapture.gemspec
@@ -19,7 +19,7 @@
 Gem::Specification.new do |spec|
   spec.name        =  'wrapture'
   spec.version     =  '0.4.2'
-  spec.date        =  '2020-05-10'
+  spec.date        =  '2020-05-11'
   spec.summary     =  'wrap C in C++'
   spec.description =  'Wraps C code in C++.'
   spec.authors     =  ['Joel Anderson']

--- a/wrapture.gemspec
+++ b/wrapture.gemspec
@@ -19,7 +19,7 @@
 Gem::Specification.new do |spec|
   spec.name        =  'wrapture'
   spec.version     =  '0.4.2'
-  spec.date        =  '2020-05-09'
+  spec.date        =  '2020-05-10'
   spec.summary     =  'wrap C in C++'
   spec.description =  'Wraps C code in C++.'
   spec.authors     =  ['Joel Anderson']


### PR DESCRIPTION
Constructors that had an error check specified using an `error-check` key referenced a local variable named `return_val`, but this variable was not assigned to prior to the usage. This resulted in segmentation faults upon execution. This has been corrected by using the equivalent struct member of the class in constructors, and not generating the local variable at all.

This fixes #84, which can be referenced for more details.