### PR TITLE
add version to sonar properties

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,4 +49,6 @@ script:
   - gem install wrapture
 
 after_success:
+  - VERSION=$(ruby -I ./lib -r wrapture -e "puts Wrapture::VERSION")
+  - echo "sonar.projectVersion=$VERSION" >> sonar-project.properties
   - sonar-scanner


### PR DESCRIPTION
After build success, add the version of the library (from the `Wrapture::VERSION` constant) to the `sonar-project.properties` file so that it is correctly reported in the sonarcloud project overview.