### PR TITLE
bring coverage back up

### DIFF
--- a/lib/wrapture/class_spec.rb
+++ b/lib/wrapture/class_spec.rb
@@ -470,6 +470,19 @@ module Wrapture
       @scope.overloads(self).map { |overload| "#{overload.name}.hpp" }
     end
 
+    # The initializer for the pointer constructor, if one is available, or an
+    # empty string if not.
+    def parent_provides_initializer?
+      if pointer_wrapper? && child?
+        parent_spec = @scope.type(TypeSpec.new(parent_name))
+        return !parent_spec.nil? &&
+               parent_spec.pointer_wrapper? &&
+               parent_spec.struct_name == @struct.name
+      end
+
+      return false
+    end
+
     # Yields the declaration of the pointer constructor for a class.
     #
     # If this class does not have an equivalent struct, or if there is already
@@ -523,15 +536,11 @@ module Wrapture
     # The initializer for the pointer constructor, if one is available, or an
     # empty string if not.
     def pointer_constructor_initializer
-      if pointer_wrapper? && child?
-        parent_spec = @scope.type(TypeSpec.new(parent_name))
-        parent_usable = !parent_spec.nil? &&
-                        parent_spec.pointer_wrapper? &&
-                        parent_spec.struct_name == @struct.name
-        return ": #{parent_name}( equivalent ) " if parent_usable
+      if parent_provides_initializer?
+        ": #{parent_name}( equivalent ) "
+      else
+        ''
       end
-
-      ''
     end
 
     # The signature of the constructor given an equivalent strucct pointer.

--- a/lib/wrapture/class_spec.rb
+++ b/lib/wrapture/class_spec.rb
@@ -473,12 +473,13 @@ module Wrapture
     # The initializer for the pointer constructor, if one is available, or an
     # empty string if not.
     def parent_provides_initializer?
-      if pointer_wrapper? && child?
-        parent_spec = @scope.type(TypeSpec.new(parent_name))
-        return !parent_spec.nil? &&
-               parent_spec.pointer_wrapper? &&
-               parent_spec.struct_name == @struct.name
-      end
+      return false if !pointer_wrapper? || !child?
+
+      parent_spec = @scope.type(TypeSpec.new(parent_name))
+
+      !parent_spec.nil? &&
+        parent_spec.pointer_wrapper? &&
+        parent_spec.struct_name == @struct.name
     end
 
     # Yields the declaration of the pointer constructor for a class.

--- a/lib/wrapture/class_spec.rb
+++ b/lib/wrapture/class_spec.rb
@@ -479,8 +479,6 @@ module Wrapture
                parent_spec.pointer_wrapper? &&
                parent_spec.struct_name == @struct.name
       end
-
-      return false
     end
 
     # Yields the declaration of the pointer constructor for a class.

--- a/test/fixtures/pointer_class_and_child_with_different_struct.yml
+++ b/test/fixtures/pointer_class_and_child_with_different_struct.yml
@@ -1,0 +1,15 @@
+version: "0.4.0"
+classes:
+  - name: "ParentPointer"
+    namespace: "wrapture_test"
+    type: "pointer"
+    equivalent-struct:
+      name: "wrapped_struct"
+  - name: "ChildPointer"
+    namespace: "wrapture_test"
+    type: "pointer"
+    parent:
+      name: "ParentPointer"
+      includes: "ParentPointer.hpp"
+    equivalent-struct:
+      name: "wrapped_struct_but_different"

--- a/test/test_pointer_class.rb
+++ b/test/test_pointer_class.rb
@@ -85,4 +85,21 @@ class ClassSpecTest < Minitest::Test
 
     File.delete(*classes)
   end
+
+  def test_pointer_class_and_child_with_different_struct
+    test_spec = load_fixture('pointer_class_and_child_with_different_struct')
+
+    spec = Wrapture::Scope.new(test_spec)
+
+    classes = spec.generate_wrappers
+    validate_wrapper_results(test_spec, classes)
+
+    equivalent_signature = 'struct wrapped_struct \*equivalent;'
+    refute(file_contains_match('ChildPointer.hpp', equivalent_signature))
+
+    parent_initializer = 'equivalent \) : ParentPointer\('
+    refute(file_contains_match('ChildPointer.cpp', parent_initializer))
+
+    File.delete(*classes)
+  end
 end


### PR DESCRIPTION
A multi-line conditional responsible for determining whether a parent class's constructor could be use as the initializer for a child class was not completely covered, resulting in a drop in coverage when codecov began to detect this. This change refactors the conditional in question, and adds a test to ensure that it is covered.