### PR TITLE
fix return value variables

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,7 +9,10 @@ For a detailed look at the project's future, including planned features and bug
 fixes, check out the
 [roadmap](https://github.com/goatshriek/wrapture/blob/master/docs/roadmap.md).
 
-## [0.5.0] - 2020-05-11
+## [0.5.0] - 2020-12-14
+### Fixed
+ - Return values are now properly declared, captured, and returned as needed.
+
 ### Removed
  - Ruby 2.3 is no longer supported.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,9 +7,8 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.1)
-    codecov (0.2.12)
-      json
-      simplecov
+    codecov (0.2.13)
+      simplecov (~> 0.18.0)
     docile (1.3.2)
     json (2.3.1)
     json (2.3.1-java)
@@ -22,7 +21,7 @@ GEM
     rdoc (6.2.1)
     regexp_parser (2.0.0)
     rexml (3.2.4)
-    rubocop (1.5.2)
+    rubocop (1.6.1)
       parallel (~> 1.10)
       parser (>= 2.7.1.5)
       rainbow (>= 2.2.2, < 4.0)
@@ -43,9 +42,10 @@ GEM
 PLATFORMS
   java
   ruby
+  x86_64-linux
 
 DEPENDENCIES
-  bundler (>= 1.6.4, < 2.2)
+  bundler (>= 1.6.4, < 2.3)
   codecov (>= 0.1.14)
   json (~> 2.3)
   minitest (>= 5.9, < 5.12)
@@ -56,4 +56,4 @@ DEPENDENCIES
   wrapture!
 
 BUNDLED WITH
-   2.1.4
+   2.2.0

--- a/test/fixtures/basic_function.yml
+++ b/test/fixtures/basic_function.yml
@@ -8,5 +8,4 @@ wrapped-function:
     - "folder/include_file_2.h"
     - "folder/include_file_3.h"
   params:
-    - name: "equivalent-struct-pointer"
     - name: "app_name"

--- a/test/fixtures/exception_check_without_return_val.yml
+++ b/test/fixtures/exception_check_without_return_val.yml
@@ -1,0 +1,18 @@
+name: "ErrorCheckWithoutReturnVal"
+return:
+  type: "int"
+wrapped-function:
+  name: "underlying_function"
+  error-check:
+    rules:
+      - left-expression: "it_failed(  )"
+        condition: "not-equals"
+        right-expression: "false"
+    error-action:
+      name: "throw-exception"
+      constructor:
+        name: "CodeException"
+        params:
+          - value: "failure_code(  )"
+  return:
+    type: "int"

--- a/test/fixtures/self_reference_class.yml
+++ b/test/fixtures/self_reference_class.yml
@@ -1,11 +1,11 @@
-name: "BasicClass"
+name: "SelfReferenceClass"
 namespace: "wrapture_test"
 includes: "class_include.h"
 equivalent-struct:
   name: "basic_struct"
   includes: "folder/include_file_1.h"
 functions:
-  - name: "BasicFunction1"
+  - name: "SelfReferenceFunction"
     params:
       - name: "app_name"
         type: "const char *"

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -63,7 +63,7 @@ end
 
 def block_collector
   lines = []
-  proc { |line| lines << line }
+  proc { |line| lines << line unless line.nil? }
 end
 
 def count_matches(filename, regex)

--- a/test/test_function_spec.rb
+++ b/test/test_function_spec.rb
@@ -26,7 +26,8 @@ class FunctionSpecTest < Minitest::Test
   def test_basic_new
     test_spec = load_fixture('basic_function')
 
-    Wrapture::FunctionSpec.new(test_spec)
+    spec = Wrapture::FunctionSpec.new(test_spec)
+    spec.definition(&block_collector)
   end
 
   def test_documentation
@@ -60,6 +61,16 @@ class FunctionSpecTest < Minitest::Test
 
       assert(code.include?(throw_code)) if code.start_with?('throw')
     end
+  end
+
+  def test_exception_without_return_val
+    test_spec = load_fixture('exception_check_without_return_val')
+
+    spec = Wrapture::FunctionSpec.new(test_spec)
+
+    lines = spec.definition(&block_collector)
+    assert(lines.any? { |line| line.end_with?('int return_val;') } )
+    assert(lines.any? { |line| line.end_with?('return return_val;') } )
   end
 
   def test_function_pointer_argument

--- a/test/test_function_spec.rb
+++ b/test/test_function_spec.rb
@@ -69,8 +69,8 @@ class FunctionSpecTest < Minitest::Test
     spec = Wrapture::FunctionSpec.new(test_spec)
 
     lines = spec.definition(&block_collector)
-    assert(lines.any? { |line| line.end_with?('int return_val;') } )
-    assert(lines.any? { |line| line.end_with?('return return_val;') } )
+    assert(lines.any? { |line| line.end_with?('int return_val;') })
+    assert(lines.any? { |line| line.end_with?('return return_val;') })
   end
 
   def test_function_pointer_argument

--- a/test/test_self_reference.rb
+++ b/test/test_self_reference.rb
@@ -39,6 +39,7 @@ class SelfReferenceTest < Minitest::Test
 
     source_file = "#{test_spec['name']}.cpp"
     assert(file_contains_match(source_file, /return \*this;/))
+    refute(file_contains_match(source_file, 'return_val'))
 
     File.delete(*generated_files)
   end

--- a/wrapture.gemspec
+++ b/wrapture.gemspec
@@ -19,7 +19,7 @@
 Gem::Specification.new do |spec|
   spec.name        =  'wrapture'
   spec.version     =  '0.5.0'
-  spec.date        =  '2020-05-11'
+  spec.date        =  '2020-12-14'
   spec.summary     =  'wrap C in C++'
   spec.description =  'Wraps C code in C++.'
   spec.authors     =  ['Joel Anderson']

--- a/wrapture.gemspec
+++ b/wrapture.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.license     =  'Apache-2.0'
 
   spec.required_ruby_version = '>= 2.4'
-  spec.add_development_dependency 'bundler', '>= 1.6.4', '< 2.2'
+  spec.add_development_dependency 'bundler', '>= 1.6.4', '< 2.3'
 
   if spec.respond_to?(:metadata)
     spec.metadata = {


### PR DESCRIPTION
Return values were not properly declared, captured, or returned for some functions, resulting in improper functionality in some cases and code that would not compile in others. This has been rectified so that return values are properly captured in cases where an error check needs to happen before returning, even if the check itself does not use the return value.