### PR TITLE
fix executable version check

### DIFF
--- a/bin/wrapture
+++ b/bin/wrapture
@@ -26,6 +26,10 @@ scope = Wrapture::Scope.new
 ARGV.each do |spec_file|
   spec = YAML.load_file(spec_file)
 
+  if spec.key?('version') && !Wrapture.supports_version?(spec['version'])
+    raise Wrapture::UnsupportedSpecVersion
+  end
+
   spec.fetch('templates', []).each do |temp_spec|
     scope << Wrapture::TemplateSpec.new(temp_spec)
   end


### PR DESCRIPTION
When generating classes using the `bin/wrapture` script, the versions of the provided specs was not checked. This meant that old versions of wrapture would still attempt to generate wrappers for specs using features for newer versions. This check has been added to the executable script so that an error is thrown when a newer version spec than what the running version can handle is provided.