### PR TITLE
update roadmap for v0.6.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,9 +9,10 @@ For a detailed look at the project's future, including planned features and bug
 fixes, check out the
 [roadmap](https://github.com/goatshriek/wrapture/blob/master/docs/roadmap.md).
 
-## [0.5.0] - 2020-12-14
+## [0.5.0] - 2020-12-15
 ### Fixed
  - Return values are now properly declared, captured, and returned as needed.
+ - `bin/wrapture` now checks the version number of specs it processes.
 
 ### Removed
  - Ruby 2.3 is no longer supported.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,37 +4,7 @@ See below for details about upcoming releases of Wrapture. If you have feedback
 or want to make a suggestion, please submit an issue on the project's
 [Github page](https://github.com/goatshriek/wrapture).
 
-## What you'll find here and what you wont
-
-Wrapture is under active development, and has a long list of new features and
-improvements waiting to be implemented. Some of these are detailed in the issues
-list on the project Github website, but this is certainly not a comprehensive
-list of planned updates. Similarly, work that is in progress on new features is
-tracked as a project on the Github repository, but future planned work does not
-exist there either. Instead, the plans for future direction are kept here, in
-the project roadmap.
-
-Items are added to the roadmap once they have been identified, assessed for
-level of effort, and prioritized based on community needs. Each item is assigned
-to a semantic version, along with its change type, a description, and the
-reasoning behind it. Where they exist, you will see references to issues on the
-Github repository where you can go for more details on the origin of the
-request. Once a version is in work, you will be able to find a corresponding
-project on the Github repository with each roadmap item listed as a task. Once
-all tasks are complete, the version will be released and the next started.
-
-Once an item has been implemented it will be removed from the roadmap. If you
-would like to see a history of changes on the existing codebase, check out the
-ChangeLog (ChangeLog.md in the project root) to see what was included in each
-version of the library. In most cases, roadmap items will be removed from this
-document and placed there upon completion.
-
-Note that the timelines associated with each change are vague at best. The
-project team is not currently big enough to realistically make any promises, so
-timing is often left out to prevent folks from feeling cheated if something
-takes longer than expected.
-
-## 0.5.0
+## 0.6.0
  * [ADD] **Python class generation**
    Python is a commonly used language in a variety of applications, and
    extension of C code into it is estimated to be a valuable feature.
@@ -120,6 +90,36 @@ takes longer than expected.
    language code itself rather than injecting special behavior into the
    wrappers. If you would like to provide feedback on this decision, please
    submit an issue on the project's Github page.
+
+
+## What you'll find here and what you wont
+Wrapture is under active development, and has a long list of new features and
+improvements waiting to be implemented. Some of these are detailed in the issues
+list on the project Github website, but this is certainly not a comprehensive
+list of planned updates. Similarly, work that is in progress on new features is
+tracked as a project on the Github repository, but future planned work does not
+exist there either. Instead, the plans for future direction are kept here, in
+the project roadmap.
+
+Items are added to the roadmap once they have been identified, assessed for
+level of effort, and prioritized based on community needs. Each item is assigned
+to a semantic version, along with its change type, a description, and the
+reasoning behind it. Where they exist, you will see references to issues on the
+Github repository where you can go for more details on the origin of the
+request. Once a version is in work, you will be able to find a corresponding
+project on the Github repository with each roadmap item listed as a task. Once
+all tasks are complete, the version will be released and the next started.
+
+Once an item has been implemented it will be removed from the roadmap. If you
+would like to see a history of changes on the existing codebase, check out the
+ChangeLog (ChangeLog.md in the project root) to see what was included in each
+version of the library. In most cases, roadmap items will be removed from this
+document and placed there upon completion.
+
+Note that the timelines associated with each change are vague at best. The
+project team is not currently big enough to realistically make any promises, so
+timing is often left out to prevent folks from feeling cheated if something
+takes longer than expected.
 
 
 ## A Note about Github issues and projects

--- a/wrapture.gemspec
+++ b/wrapture.gemspec
@@ -19,7 +19,7 @@
 Gem::Specification.new do |spec|
   spec.name        =  'wrapture'
   spec.version     =  '0.5.0'
-  spec.date        =  '2020-12-14'
+  spec.date        =  '2020-12-15'
   spec.summary     =  'wrap C in C++'
   spec.description =  'Wraps C code in C++.'
   spec.authors     =  ['Joel Anderson']


### PR DESCRIPTION
Python class generation has been pushed to 0.6.0 in order to allow other fixes and features to be released in v0.5.0 now for use in stumpless.