### PR TITLE
add new rubocop extensions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,7 @@
+require:
+  - rubocop-minitest
+  - rubocop-rake
+
 AllCops:
   TargetRubyVersion: 2.4
   NewCops: enable
@@ -18,6 +22,9 @@ Metrics/MethodLength:
   Max: 55
 
 Metrics/PerceivedComplexity:
+  Max: 10
+
+Minitest/MultipleAssertions:
   Max: 10
 
 Style/Documentation:

--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,8 @@ group :test do
   # minitest at or above 5.12 cause problems with rbx 4
   gem 'minitest', '>= 5.9', '< 5.12'
   gem 'rubocop', '>= 0.69', require: false
+  gem 'rubocop-minitest', require: false
+  gem 'rubocop-rake', require: false
   # simplecov 0.19 and above require ruby 2.5
   gem 'simplecov', '>= 0.16.1', '< 0.19', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,6 +33,10 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.4.1)
       parser (>= 2.7.1.5)
+    rubocop-minitest (0.10.3)
+      rubocop (>= 0.87, < 2.0)
+    rubocop-rake (0.5.1)
+      rubocop
     ruby-progressbar (1.11.0)
     simplecov (0.18.5)
       docile (~> 1.1)
@@ -52,8 +56,10 @@ DEPENDENCIES
   rake (>= 0.9.2)
   rdoc (>= 6.0)
   rubocop (>= 0.69)
+  rubocop-minitest
+  rubocop-rake
   simplecov (>= 0.16.1, < 0.19)
   wrapture!
 
 BUNDLED WITH
-   2.2.8
+   2.2.9

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -99,8 +99,8 @@ def refute_keywords_found(filename)
   File.open(filename) do |file|
     file.each do |line|
       Wrapture::KEYWORDS.each do |keyword|
-        refute(line.include?(keyword),
-               "#{filename} had keyword '#{keyword}' on line #{file.lineno}")
+        err_msg = "#{filename} had keyword '#{keyword}' on line #{file.lineno}"
+        refute_includes(line, keyword, err_msg)
       end
     end
   end
@@ -110,8 +110,8 @@ def validate_class_wrapper(spec, file_list)
   refute_nil(file_list)
   refute_empty(file_list)
 
-  assert(file_list.include?("#{spec['name']}.cpp"))
-  assert(file_list.include?("#{spec['name']}.hpp"))
+  assert_includes(file_list, "#{spec['name']}.cpp")
+  assert_includes(file_list, "#{spec['name']}.hpp")
 
   validate_declaration_file(spec)
   validate_definition_file(spec)
@@ -215,7 +215,7 @@ def validate_wrapper_results(spec, file_list)
       validate_class_wrapper(class_spec, file_list)
     end
   else
-    assert(file_list.length == 2, msg: 'only 2 files expected per class')
+    assert_equal(2, file_list.length, msg: 'only 2 files expected per class')
     validate_class_wrapper(spec, file_list)
   end
 end

--- a/test/test_action_spec.rb
+++ b/test/test_action_spec.rb
@@ -33,7 +33,7 @@ class ActionSpecTest < Minitest::Test
 
     action = spec.take
 
-    assert(action.include?('throw NewCustomException'))
+    assert_includes(action, 'throw NewCustomException')
   end
 
   def test_exception_without_params

--- a/test/test_constant_spec.rb
+++ b/test/test_constant_spec.rb
@@ -25,8 +25,8 @@ class ConstantSpecTest < Minitest::Test
       comment << line << "\n"
     end
 
-    refute(comment.empty?)
-    assert(comment.include?('ConstantDocIdentifier'))
+    refute_empty(comment)
+    assert_includes(comment, 'ConstantDocIdentifier')
   end
 
   def test_future_spec_version

--- a/test/test_enum_spec.rb
+++ b/test/test_enum_spec.rb
@@ -70,7 +70,7 @@ class EnumSpecTest < Minitest::Test
       Wrapture::EnumSpec.new(test_spec)
     end
 
-    %w[elements array].each { |word| assert(error.message.include?(word)) }
+    %w[elements array].each { |word| assert_includes(error.message, word) }
   end
 
   def test_enum_with_namespace
@@ -96,7 +96,7 @@ class EnumSpecTest < Minitest::Test
       Wrapture::EnumSpec.new(test_spec)
     end
 
-    %w[elements required].each { |word| assert(error.message.include?(word)) }
+    %w[elements required].each { |word| assert_includes(error.message, word) }
   end
 
   def test_no_name
@@ -106,7 +106,7 @@ class EnumSpecTest < Minitest::Test
       Wrapture::EnumSpec.new(test_spec)
     end
 
-    %w[name required].each { |word| assert(error.message.include?(word)) }
+    %w[name required].each { |word| assert_includes(error.message, word) }
   end
 
   def validate_file_matches_spec(filename, spec_hash)

--- a/test/test_function_spec.rb
+++ b/test/test_function_spec.rb
@@ -42,10 +42,10 @@ class FunctionSpecTest < Minitest::Test
       comment << line << "\n"
     end
 
-    refute(comment.empty?)
-    assert(comment.include?('FunctionDocIdentifier'))
-    assert(comment.include?('ParamDocIdentifier'))
-    assert(comment.include?('ReturnDocIdentifier'))
+    refute_empty(comment)
+    assert_includes(comment, 'FunctionDocIdentifier')
+    assert_includes(comment, 'ParamDocIdentifier')
+    assert_includes(comment, 'ReturnDocIdentifier')
   end
 
   def test_exception_throwing_function
@@ -59,7 +59,7 @@ class FunctionSpecTest < Minitest::Test
 
       code = line.strip
 
-      assert(code.include?(throw_code)) if code.start_with?('throw')
+      assert_includes(code, throw_code) if code.start_with?('throw')
     end
   end
 
@@ -182,8 +182,8 @@ class FunctionSpecTest < Minitest::Test
       comment << line << "\n"
     end
 
-    refute(comment.empty?)
-    assert(comment.include?('ParamDocIdentifier'))
+    refute_empty(comment)
+    assert_includes(comment, 'ParamDocIdentifier')
   end
 
   def test_only_variadic_param
@@ -193,7 +193,7 @@ class FunctionSpecTest < Minitest::Test
       Wrapture::FunctionSpec.new(test_spec)
     end
 
-    assert(error.message.include?('only param'))
+    assert_includes(error.message, 'only param')
   end
 
   def test_undefinable
@@ -215,17 +215,17 @@ class FunctionSpecTest < Minitest::Test
       spec = Wrapture::FunctionSpec.new(test_spec)
 
       spec.declaration do |line|
-        assert(line.include?('...'))
+        assert_includes(line, '...')
       end
 
       assert(spec.signature.end_with?('... )'))
 
-      assert(spec.definition_includes.include?('stdarg.h'))
+      assert_includes(spec.definition_includes, 'stdarg.h')
 
       spec.definition do |line|
         code = line.strip
 
-        assert(code.include?('variadic_args')) if code.include?('underlying')
+        assert_includes(code, 'variadic_args') if code.include?('underlying')
       end
     end
   end

--- a/test/test_invalid.rb
+++ b/test/test_invalid.rb
@@ -86,7 +86,7 @@ class InvalidTest < Minitest::Test
       Wrapture::Scope.new(scope_spec)
     end
 
-    assert(error.message.include?(Wrapture::TEMPLATE_USE_KEYWORD))
+    assert_includes(error.message, Wrapture::TEMPLATE_USE_KEYWORD)
   end
 
   def test_use_template_with_no_name

--- a/test/test_param_spec.rb
+++ b/test/test_param_spec.rb
@@ -30,7 +30,7 @@ class ParamSpecTest < Minitest::Test
       Wrapture::ParamSpec.new(test_spec)
     end
 
-    assert(error.message.include?('type'))
+    assert_includes(error.message, 'type')
   end
 
   def test_variadic_parameter

--- a/test/test_self_reference.rb
+++ b/test/test_self_reference.rb
@@ -33,7 +33,7 @@ class SelfReferenceTest < Minitest::Test
 
     forbidden = Wrapture::SELF_REFERENCE_KEYWORD
     generated_files.each do |filename|
-      assert(!file_contains_match(filename, forbidden),
+      refute(file_contains_match(filename, forbidden),
              "#{filename} should not contain '#{forbidden}'")
     end
 

--- a/test/test_template.rb
+++ b/test/test_template.rb
@@ -83,7 +83,7 @@ class TemplateSpecTest < Minitest::Test
     assert(usage.key?('places'))
     assert(usage.key?('key-1'))
     assert_instance_of(Array, usage['other-stuff'])
-    assert(usage['other-stuff'].include?('thing-2'))
+    assert_includes(usage['other-stuff'], 'thing-2')
   end
 
   def test_no_param_instantiation
@@ -113,12 +113,12 @@ class TemplateSpecTest < Minitest::Test
 
     temp.replace_uses(usage)
 
-    assert(usage.include?('thing-1'))
-    assert(usage.include?('thing-2'))
-    assert(usage.include?('thing-a'))
-    assert(usage.include?('thing-b'))
+    assert_includes(usage, 'thing-1')
+    assert_includes(usage, 'thing-2')
+    assert_includes(usage, 'thing-a')
+    assert_includes(usage, 'thing-b')
     assert(usage.last.is_a?(Hash))
-    assert(usage.last['key-1'] == 'thing-3')
+    assert_equal('thing-3', usage.last['key-1'])
   end
 
   def test_replace_in_hash

--- a/test/test_type_spec.rb
+++ b/test/test_type_spec.rb
@@ -28,6 +28,6 @@ class TypeSpecTest < Minitest::Test
   end
 
   def test_equality_with_string
-    assert(Wrapture::TypeSpec.new('const char *') == 'const char *')
+    assert_equal('const char *', Wrapture::TypeSpec.new('const char *'))
   end
 end

--- a/test/test_type_spec.rb
+++ b/test/test_type_spec.rb
@@ -2,7 +2,7 @@
 
 # frozen_string_literal: true
 
-# Copyright 2020 Joel E. Anderson
+# Copyright 2020-2021 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ class TypeSpecTest < Minitest::Test
   end
 
   def test_equality_with_string
-    assert_equal(Wrapture::TypeSpec.new('const char *'), 'const char *')
+    type_name = 'const char *'
+    assert_equal(Wrapture::TypeSpec.new(type_name), type_name)
   end
 end

--- a/test/test_type_spec.rb
+++ b/test/test_type_spec.rb
@@ -24,10 +24,10 @@ require 'wrapture'
 
 class TypeSpecTest < Minitest::Test
   def test_equality_with_int
-    refute(Wrapture::TypeSpec.new('conswt char *') == 3)
+    refute(Wrapture::TypeSpec.new('const char *') == 3)
   end
 
   def test_equality_with_string
-    assert_equal('const char *', Wrapture::TypeSpec.new('const char *'))
+    assert_equal(Wrapture::TypeSpec.new('const char *'), 'const char *')
   end
 end


### PR DESCRIPTION
This change adds two rubocop extensions for rake and minitest, and corrects the issues that they raised attention to.