### PR TITLE
factor names into separate words

### DIFF
--- a/docs/examples/constants/vcr.yml
+++ b/docs/examples/constants/vcr.yml
@@ -1,5 +1,5 @@
 classes:
-  - name: "VCR"
+  - name: "Vcr"
     namespace: "mediacenter"
     libraries: "vcr"
     equivalent-struct:

--- a/docs/examples/constants/vcr_usage.cpp
+++ b/docs/examples/constants/vcr_usage.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * Copyright 2023 Joel E. Anderson
+ * Copyright 2023-2025 Joel E. Anderson
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,16 +17,16 @@
  */
 
 #include <cstdlib>
-#include <VCR.hpp>
+#include <Vcr.hpp>
 
 using namespace mediacenter;
 
 int main(int argc, char **argv) {
-  VCR living_room ( 3 );
-  VCR bedroom ( 4 );
+  Vcr living_room ( 3 );
+  Vcr bedroom ( 4 );
 
-  living_room.SendCommand( VCR::PAUSE_COMMAND );
-  bedroom.SendCommand( VCR::PLAY_COMMAND );
+  living_room.SendCommand( Vcr::PAUSE_COMMAND );
+  bedroom.SendCommand( Vcr::PLAY_COMMAND );
 
   return EXIT_SUCCESS;
 }

--- a/docs/examples/constants/vcr_usage.py
+++ b/docs/examples/constants/vcr_usage.py
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2023 Joel E. Anderson
+# Copyright 2023-2025 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,8 +18,8 @@
 
 import mediacenter
 
-living_room = mediacenter.VCR(3)
-bedroom = mediacenter.VCR(4)
+living_room = mediacenter.Vcr(3)
+bedroom = mediacenter.Vcr(4)
 
 living_room.SendCommand(living_room.PAUSE_COMMAND)
 bedroom.SendCommand(bedroom.PLAY_COMMAND)

--- a/lib/wrapture/c_to_cpp_wrapper.rb
+++ b/lib/wrapture/c_to_cpp_wrapper.rb
@@ -597,7 +597,7 @@ module Wrapture
       factory_lines << "  return new #{@spec.name}( equivalent );"
       factory_lines << '}'
 
-      { 'name' => "new#{@spec.name}",
+      { 'name' => ['new'] + @spec.name_words,
         'static' => true,
         'params' => [{ 'name' => 'equivalent',
                        'type' => 'equivalent-struct-pointer' }],

--- a/lib/wrapture/c_to_python_wrapper.rb
+++ b/lib/wrapture/c_to_python_wrapper.rb
@@ -346,7 +346,6 @@ module Wrapture
     # Passes lines of C code to the given block which creates the methods and
     # type object for the given class in this module.
     def define_class_type_object(class_spec, &block)
-      # define_class_type_struct(class_spec) { |line| block.call(line) }
       yield ''
 
       class_function_groups(class_spec).each do |func_group|
@@ -373,7 +372,9 @@ module Wrapture
       yield "  .tp_doc = \"#{class_spec.doc.text}\","
       yield "  .tp_basicsize = sizeof( #{type_struct_name(class_spec)} ),"
       yield '  .tp_itemsize = 0,'
-      yield '  .tp_flags = Py_TPFLAGS_DEFAULT,'
+      flags = 'Py_TPFLAGS_DEFAULT'
+      flags += ' | Py_TPFLAGS_BASETYPE' if class_spec.parent?
+      yield "  .tp_flags = #{flags},"
       yield "  .tp_new = #{snake_name}_new,"
       yield "  .tp_dealloc = ( destructor ) #{snake_name}_dealloc,"
       yield "  .tp_methods = #{snake_name}_methods,"
@@ -488,6 +489,9 @@ module Wrapture
       yield 'static int'
       name = "parse_#{function_wrapper_name(func_spec)}" if name.nil?
       signature_declarations = []
+      parse_args = []
+      parse_locals = []
+
       func_spec.params.each do |param_spec|
         param_type_spec = func_spec.resolve_type(param_spec.type)
         param_type = if func_spec.owner.scope.type?(param_type_spec)
@@ -496,12 +500,37 @@ module Wrapture
                        "#{param_type_spec} *"
                      end
         signature_declarations << "#{param_type} #{param_spec.name}"
+
+        parse_args << if param_type_spec == 'bool'
+                        parse_locals << { name: "#{param_spec.name}_int",
+                                          decl: "int #{param_spec.name}_int;",
+                                          param: param_spec.name }
+                        "&#{param_spec.name}_int"
+                      else
+                        param_spec.name
+                      end
       end
       wrapped_args = signature_declarations.join(', ')
       yield "#{name}( PyObject *args, PyObject *kwds, #{wrapped_args} ) {"
+      parse_locals.each { |local| yield local[:decl] }
+      unless parse_locals.empty?
+        yield 'int parse_result;'
+        yield ''
+      end
+
       format_str = "\"#{function_args_format(func_spec)}\""
-      params = func_spec.param_names.join(', ')
-      yield "  return PyArg_ParseTuple( args, #{format_str}, #{params} );"
+      params = parse_args.join(', ')
+      parse_call = "PyArg_ParseTuple( args, #{format_str}, #{params} )"
+
+      if parse_locals.empty?
+        yield "  return #{parse_call};"
+      else
+        yield "  parse_result = #{parse_call};"
+        parse_locals.each do |local|
+          yield "  *#{local[:param]} = #{local[:name]};"
+        end
+        yield '  return parse_result;'
+      end
       yield '}'
     end
 

--- a/lib/wrapture/class_spec.rb
+++ b/lib/wrapture/class_spec.rb
@@ -296,8 +296,16 @@ module Wrapture
         !@struct.rules.empty?
     end
 
+    # True if this class is a parent of others.
+    def parent?
+      @scope.classes.any? do |class_spec|
+        class_spec.parent_name == name
+      end
+    end
+
     # The name of the parent of this class, or nil if there is no parent.
     def parent_name
+      # TODO: this needs to use the actual class spec method instead of the hash
       @spec['parent']['name'] if child?
     end
 

--- a/lib/wrapture/class_spec.rb
+++ b/lib/wrapture/class_spec.rb
@@ -270,9 +270,6 @@ module Wrapture
       @functions.select { |spec| !spec.constructor? && !spec.destructor? }
     end
 
-    # The name of the class.
-    alias name raw_name
-
     # The words that make up the function name.
     def name_words
       @spec['name']

--- a/lib/wrapture/class_spec.rb
+++ b/lib/wrapture/class_spec.rb
@@ -72,6 +72,8 @@ module Wrapture
       raise MissingNamespace unless spec.key?('namespace')
       raise MissingSpecKey, 'name key is required' unless spec.key?('name')
 
+      spec['name'] = Wrapture.normalize_name(spec, 'name')
+
       if spec.key?('doc')
         Comment.validate_doc(spec['doc'])
       else
@@ -269,7 +271,10 @@ module Wrapture
     end
 
     # The name of the class.
-    def name
+    alias name raw_name
+
+    # The words that make up the function name.
+    def name_words
       @spec['name']
     end
 

--- a/lib/wrapture/constant_spec.rb
+++ b/lib/wrapture/constant_spec.rb
@@ -83,9 +83,6 @@ module Wrapture
     end
 
     # The name of the constant.
-    alias name raw_name
-
-    # The name of the constant.
     def name_words
       @spec['name']
     end

--- a/lib/wrapture/constant_spec.rb
+++ b/lib/wrapture/constant_spec.rb
@@ -3,7 +3,7 @@
 # frozen_string_literal: true
 
 #--
-# Copyright 2019-2023 Joel E. Anderson
+# Copyright 2019-2025 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -42,6 +42,7 @@ module Wrapture
       spec['doc'] = '' unless spec.key?('doc')
       Comment.validate_doc(spec['doc'])
 
+      spec['name'] = Wrapture.normalize_name(spec, 'name')
       spec['version'] = Wrapture.spec_version(spec)
       spec['includes'] = Wrapture.normalize_array(spec['includes'])
 
@@ -82,7 +83,10 @@ module Wrapture
     end
 
     # The name of the constant.
-    def name
+    alias name raw_name
+
+    # The name of the constant.
+    def name_words
       @spec['name']
     end
 

--- a/lib/wrapture/enum_spec.rb
+++ b/lib/wrapture/enum_spec.rb
@@ -123,9 +123,6 @@ module Wrapture
     end
 
     # The name of the constant.
-    alias name raw_name
-
-    # The name of the constant.
     def name_words
       @spec['name']
     end

--- a/lib/wrapture/enum_spec.rb
+++ b/lib/wrapture/enum_spec.rb
@@ -3,7 +3,7 @@
 # frozen_string_literal: true
 
 #--
-# Copyright 2020-2023 Joel E. Anderson
+# Copyright 2020-2025 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -40,6 +40,8 @@ module Wrapture
       unless spec.key?('name')
         raise MissingSpecKey, 'a name is required for enumerations'
       end
+
+      spec['name'] = Wrapture.normalize_name(spec, 'name')
 
       if spec.key?('elements')
         unless spec['elements'].is_a?(Array)
@@ -120,8 +122,11 @@ module Wrapture
       @spec['libraries']
     end
 
-    # The name of the enumeration.
-    def name
+    # The name of the constant.
+    alias name raw_name
+
+    # The name of the constant.
+    def name_words
       @spec['name']
     end
 

--- a/lib/wrapture/function_spec.rb
+++ b/lib/wrapture/function_spec.rb
@@ -240,9 +240,6 @@ module Wrapture
       end
     end
 
-    # The name of the function.
-    alias name raw_name
-
     # The words that make up the function name.
     def name_words
       @spec['name']

--- a/lib/wrapture/function_spec.rb
+++ b/lib/wrapture/function_spec.rb
@@ -61,6 +61,7 @@ module Wrapture
       Wrapture.normalize_boolean!(spec, 'virtual')
       spec['params'] = ParamSpec.normalize_param_list(spec['params'])
       spec['return'] = normalize_return_hash(spec['return'])
+      spec['name'] = Wrapture.normalize_name(spec, 'name')
 
       spec['initializers'] = [] unless spec.key?('initializers')
       if spec['initializers'].any? { |i| !i.key?('name') && !i['delegate'] }
@@ -240,7 +241,10 @@ module Wrapture
     end
 
     # The name of the function.
-    def name
+    alias name raw_name
+
+    # The words that make up the function name.
+    def name_words
       @spec['name']
     end
 

--- a/lib/wrapture/named.rb
+++ b/lib/wrapture/named.rb
@@ -24,14 +24,8 @@ module Wrapture
   # This module expects that +name_words+ gives an enumerable of parts that make
   # up the name. These words are used to form the name forms that this module
   # provides.
-  #
-  # This module expects that +name+ gives a CamelCase name. Other
-  # transformations are based on this assumption. Names with multiple capital
-  # letters in sequence, such as 'AARConnection', contain an initialism and are
-  # interpreted as such. So for example, the result of +snake_case_name+ of the
-  # previous example would be 'aar_connection'.
   module Named
-    # The name in CamelCase.
+    # The name in UpperCamelCase.
     def camel_case_name
       name_words.map(&:capitalize).join
     end

--- a/lib/wrapture/named.rb
+++ b/lib/wrapture/named.rb
@@ -3,7 +3,7 @@
 # frozen_string_literal: true
 
 #--
-# Copyright 2021-2023 Joel E. Anderson
+# Copyright 2021-2025 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,17 +21,29 @@
 module Wrapture
   # Methods useful for named items such as specs.
   #
+  # This module expects that +name_words+ gives an enumerable of parts that make
+  # up the name. These words are used to form the name forms that this module
+  # provides.
+  #
   # This module expects that +name+ gives a CamelCase name. Other
   # transformations are based on this assumption. Names with multiple capital
   # letters in sequence, such as 'AARConnection', contain an initialism and are
   # interpreted as such. So for example, the result of +snake_case_name+ of the
   # previous example would be 'aar_connection'.
   module Named
-    # The name of this item in snake case.
+    # The name in CamelCase.
+    def camel_case_name
+      name_words.map(&:capitalize).join
+    end
+
+    # The raw name, obtained by joining all parts.
+    def raw_name
+      name_words.join
+    end
+
+    # The name in snake_case.
     def snake_case_name
-      name.gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
-          .gsub(/([a-z\d])([A-Z])/, '\1_\2')
-          .downcase
+      name_words.map(&:downcase).join('_')
     end
   end
 end

--- a/lib/wrapture/named.rb
+++ b/lib/wrapture/named.rb
@@ -41,6 +41,9 @@ module Wrapture
       name_words.join
     end
 
+    # The default name is the raw one.
+    alias name raw_name
+
     # The name in snake_case.
     def snake_case_name
       name_words.map(&:downcase).join('_')

--- a/lib/wrapture/normalize.rb
+++ b/lib/wrapture/normalize.rb
@@ -3,7 +3,7 @@
 # frozen_string_literal: true
 
 #--
-# Copyright 2019 Joel E. Anderson
+# Copyright 2019-2025 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,6 +19,19 @@
 #++
 
 module Wrapture
+  # Normalizes an array in a spec, such as an include list for an element. A
+  # single string will be converted into an array containing the single string,
+  # and a nil will be converted to an empty array.
+  def self.normalize_array(entry)
+    if entry.nil?
+      []
+    elsif entry.is_a? String
+      [entry]
+    else
+      entry.uniq
+    end
+  end
+
   # Normalizes a spec key to be boolean, raising an error if it is not. Keys
   # that are not present are defaulted to false.
   def self.normalize_boolean(spec, key)
@@ -35,16 +48,28 @@ module Wrapture
     spec[key] = normalize_boolean(spec, key)
   end
 
-  # Normalizes an array in a spec, such as an include list for an element. A
-  # single string will be converted into an array containing the single string,
-  # and a nil will be converted to an empty array.
-  def self.normalize_array(entry)
-    if entry.nil?
-      []
-    elsif entry.is_a? String
-      [entry]
+  # Normalizes a name, returning an Array of words that make up the name.
+  #
+  # If the name is a string, it is interpreted as a CamelCase name and parsed
+  # as such to extract individual words.
+  #
+  # Otherwise, the argument's to_a method is called to get the array of Strings.
+  def self.normalize_name(spec, key)
+    return [] unless spec.key?(key)
+
+    name = spec[key]
+
+    case name
+    when String
+      # first match all CamelCase strings, including preceding capital letters
+      # if the start is a lowercase word, this will be the first part
+      name.scan(/[A-Z]*[^A-Z]*/).flat_map do |s|
+        # next, split out the preceding capital letters, if any
+        s.partition(/[A-Z][^A-Z]*$/)
+      end.reject(&:empty?) # and finally, remove the empty strings
     else
-      entry.uniq
+      # use map to avoid to_a returning the argument, as for example Array does
+      name.map.to_a
     end
   end
 

--- a/lib/wrapture/scope.rb
+++ b/lib/wrapture/scope.rb
@@ -212,6 +212,9 @@ module Wrapture
       self
     end
 
+    # The name of the class.
+    alias name raw_name
+
     # The name of the scope.
     #
     # Since the name of a scope is optional, it is derived using the following
@@ -222,23 +225,23 @@ module Wrapture
     # * the name of the first class in the scope
     # * the name of the first enum in the scope
     # * an empty string
-    def name
+    def name_words
       return @spec['name'] if @spec.key?('name')
 
       @classes.each do |class_spec|
-        return class_spec.namespace unless class_spec.namespace.nil?
+        return [class_spec.namespace] unless class_spec.namespace.nil?
       end
 
       @enums.each do |enum_spec|
-        return enum_spec.namespace unless enum_spec.namespace.nil?
+        return [enum_spec.namespace] unless enum_spec.namespace.nil?
       end
 
       if @classes.any?
-        @classes.first.name
+        [@classes.first.name_words]
       elsif @enums.any?
-        @enums.first.name
+        [@enums.first.name_words]
       else
-        ''
+        []
       end
     end
 

--- a/lib/wrapture/scope.rb
+++ b/lib/wrapture/scope.rb
@@ -212,9 +212,6 @@ module Wrapture
       self
     end
 
-    # The name of the class.
-    alias name raw_name
-
     # The name of the scope.
     #
     # Since the name of a scope is optional, it is derived using the following

--- a/lib/wrapture/type_spec.rb
+++ b/lib/wrapture/type_spec.rb
@@ -98,9 +98,6 @@ module Wrapture
       includes.uniq
     end
 
-    # The name of the type.
-    alias name raw_name
-
     # The words that make up the function name.
     def name_words
       @spec['name']

--- a/lib/wrapture/type_spec.rb
+++ b/lib/wrapture/type_spec.rb
@@ -33,6 +33,7 @@ module Wrapture
     # normalize the include list.
     def self.normalize_spec_hash!(spec)
       spec['includes'] = Wrapture.normalize_array(spec['includes'])
+      spec['name'] = Wrapture.normalize_name(spec, 'name')
       spec
     end
 
@@ -48,7 +49,7 @@ module Wrapture
     # a parameter list and return type for the signature to be clear.
     def initialize(spec = 'void')
       actual_spec = if spec.is_a?(String)
-                      { 'name' => [spec] }
+                      { 'name' => spec }
                     else
                       spec
                     end

--- a/lib/wrapture/type_spec.rb
+++ b/lib/wrapture/type_spec.rb
@@ -3,7 +3,7 @@
 # frozen_string_literal: true
 
 #--
-# Copyright 2020-2024 Joel E. Anderson
+# Copyright 2020-2025 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ module Wrapture
     # a parameter list and return type for the signature to be clear.
     def initialize(spec = 'void')
       actual_spec = if spec.is_a?(String)
-                      { 'name' => spec }
+                      { 'name' => [spec] }
                     else
                       spec
                     end
@@ -98,7 +98,10 @@ module Wrapture
     end
 
     # The name of the type.
-    def name
+    alias name raw_name
+
+    # The words that make up the function name.
+    def name_words
       @spec['name']
     end
 

--- a/sig/class_spec.rbs
+++ b/sig/class_spec.rbs
@@ -44,7 +44,6 @@ module Wrapture
     def factory?: -> bool
     def libraries: -> Array[String]
     def method_specs: -> Array[Wrapture::FunctionSpec]
-    alias name raw_name
     def name_words: -> Array[String]
     def namespace: -> String
     def overloads?: (untyped parent_spec) -> bool

--- a/sig/class_spec.rbs
+++ b/sig/class_spec.rbs
@@ -1,3 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2025 Joel E. Anderson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Wrapture
   class ClassSpec
     include Named
@@ -28,7 +44,8 @@ module Wrapture
     def factory?: -> bool
     def libraries: -> Array[String]
     def method_specs: -> Array[Wrapture::FunctionSpec]
-    def name: -> String
+    alias name raw_name
+    def name_words: -> Array[String]
     def namespace: -> String
     def overloads?: (untyped parent_spec) -> bool
     def parent_name: -> (String | nil)

--- a/sig/constant_spec.rbs
+++ b/sig/constant_spec.rbs
@@ -1,3 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2025 Joel E. Anderson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Wrapture
   class ConstantSpec
     include Named
@@ -14,7 +30,8 @@ module Wrapture
     def definition_includes: -> Array[String]
     def declaration: { (String) -> void } -> void
     def definition: (String class_name) -> String
-    def name: -> String
+    alias name raw_name
+    def name_words: -> Array[String]
     def value: -> String
   end
 end

--- a/sig/constant_spec.rbs
+++ b/sig/constant_spec.rbs
@@ -30,7 +30,6 @@ module Wrapture
     def definition_includes: -> Array[String]
     def declaration: { (String) -> void } -> void
     def definition: (String class_name) -> String
-    alias name raw_name
     def name_words: -> Array[String]
     def value: -> String
   end

--- a/sig/enum_spec.rbs
+++ b/sig/enum_spec.rbs
@@ -1,3 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2025 Joel E. Anderson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Wrapture
   class EnumSpec
     include Named
@@ -13,7 +29,8 @@ module Wrapture
     def definition_includes: -> Array[String]
     def elements: -> spec_hash
     def libraries: -> Array[String]
-    def name: -> String
+    alias name raw_name
+    def name_words: -> Array[String]
     def namespace: -> (String | nil)
     def namespace?: -> bool
     def snake_case_name: -> String

--- a/sig/enum_spec.rbs
+++ b/sig/enum_spec.rbs
@@ -29,7 +29,6 @@ module Wrapture
     def definition_includes: -> Array[String]
     def elements: -> spec_hash
     def libraries: -> Array[String]
-    alias name raw_name
     def name_words: -> Array[String]
     def namespace: -> (String | nil)
     def namespace?: -> bool

--- a/sig/function_spec.rbs
+++ b/sig/function_spec.rbs
@@ -28,7 +28,6 @@ module Wrapture
     def doc: -> Wrapture::Comment
     def initializers: -> spec_hash
     def libraries: -> Array[String]
-    alias name raw_name
     def name_words: -> Array[String]
     def optional_params: -> Array[Wrapture::ParamSpec]
     def param_names: -> Array[String]

--- a/sig/function_spec.rbs
+++ b/sig/function_spec.rbs
@@ -28,7 +28,8 @@ module Wrapture
     def doc: -> Wrapture::Comment
     def initializers: -> spec_hash
     def libraries: -> Array[String]
-    def name: -> String
+    alias name raw_name
+    def name_words: -> Array[String]
     def optional_params: -> Array[Wrapture::ParamSpec]
     def param_names: -> Array[String]
     def params?: -> bool

--- a/sig/named.rbs
+++ b/sig/named.rbs
@@ -18,6 +18,7 @@ module Wrapture
   module Named
     def camel_case_name: () -> String
     def raw_name: () -> String
+    alias name raw_name
     def snake_case_name: () -> String
   end
 end

--- a/sig/named.rbs
+++ b/sig/named.rbs
@@ -16,6 +16,8 @@
 
 module Wrapture
   module Named
+    def camel_case_name: () -> String
+    def raw_name: () -> String
     def snake_case_name: () -> String
   end
 end

--- a/sig/normalize.rbs
+++ b/sig/normalize.rbs
@@ -1,6 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2025 Joel E. Anderson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Wrapture
+  def self.normalize_array: ( (Array[String] | String | nil) entry) -> Array[String]
   def self.normalize_boolean: (spec_hash spec, String key) -> bool
   def self.normalize_boolean!: (spec_hash spec, String key) -> bool
-  def self.normalize_array: ( (Array[String] | String | nil) entry) -> Array[String]
+  def self.normalize_name: (spec_hash spec, String key) -> Array[String]
   def self.spec_version: ((spec_hash | nil) spec) -> String
 end

--- a/sig/scope.rbs
+++ b/sig/scope.rbs
@@ -34,7 +34,6 @@ module Wrapture
     def each: { ((Wrapture::ClassSpec | Wrapture::EnumSpec) spec) -> void } -> void
     def libraries: -> Array[String]
     def merge_file: (String spec_filename) -> Wrapture::Scope
-    alias name raw_name
     def name_words: -> Array[String]
     def overloads: (untyped parent) -> Array[bot]
     def overloads?: (untyped parent) -> bool

--- a/sig/scope.rbs
+++ b/sig/scope.rbs
@@ -1,3 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2025 Joel E. Anderson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Wrapture
   class Scope
     include Enumerable[(Wrapture::ClassSpec | Wrapture::EnumSpec)]
@@ -18,7 +34,8 @@ module Wrapture
     def each: { ((Wrapture::ClassSpec | Wrapture::EnumSpec) spec) -> void } -> void
     def libraries: -> Array[String]
     def merge_file: (String spec_filename) -> Wrapture::Scope
-    def name: -> String
+    alias name raw_name
+    def name_words: -> Array[String]
     def overloads: (untyped parent) -> Array[bot]
     def overloads?: (untyped parent) -> bool
     def type: ( ( Wrapture::TypeSpec | String ) type ) -> ( Wrapture::ClassSpec | nil )

--- a/sig/type_spec.rbs
+++ b/sig/type_spec.rbs
@@ -1,3 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2025 Joel E. Anderson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Wrapture
   class TypeSpec
     include Named
@@ -14,7 +30,8 @@ module Wrapture
     def function: -> (Wrapture::FunctionSpec | nil)
     def function?: -> bool
     def includes: -> untyped
-    def name: -> String
+    alias name raw_name
+    def name_words: -> Array[String]
     def pointer?: -> bool
     def resolve: (Wrapture::FunctionSpec owner) -> Wrapture::TypeSpec
     def self_reference?: -> bool

--- a/sig/type_spec.rbs
+++ b/sig/type_spec.rbs
@@ -30,7 +30,6 @@ module Wrapture
     def function: -> (Wrapture::FunctionSpec | nil)
     def function?: -> bool
     def includes: -> untyped
-    alias name raw_name
     def name_words: -> Array[String]
     def pointer?: -> bool
     def resolve: (Wrapture::FunctionSpec owner) -> Wrapture::TypeSpec


### PR DESCRIPTION
Name handling was previously inconsistent, with some names being assumed to be in upper camel case, some allowed to be nil or empty, and others with no convention at all. This change updates the `Named` module to depend on a name decomposed into its separate words instead of a raw string. This allows names to be used with more flexibility and confidence.