### PR TITLE
save cmake project sources into folders

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,7 +9,7 @@ For a detailed look at the project's future, including planned features and bug
 fixes, check out the
 [roadmap](https://github.com/goatshriek/wrapture/blob/master/docs/roadmap.md).
 
-## [0.6.0] - 2026-02-22
+## [0.6.0] - Unreleased
 ### Added
  - Support for Ruby 3.2 through 3.4.
  - Ruby 2.6 is no longer supported.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,6 +15,7 @@ fixes, check out the
  - Ruby 2.6 is no longer supported.
  - RBS signatures.
  - Python wrapper generation.
+ - CMake project generation.
 
 ### Changed
  - Wrappers have been moved to their own modules, and generate build objects

--- a/lib/wrapture/build/cmake_build.rb
+++ b/lib/wrapture/build/cmake_build.rb
@@ -3,7 +3,7 @@
 # frozen_string_literal: true
 
 #--
-# Copyright 2025 Joel E. Anderson
+# Copyright 2025-2026 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -147,6 +147,39 @@ module Wrapture
       # Invocations of CMake to configure and install this project.
       def install_commands(install_dir: '.')
         ['cmake .', "cmake --install . --prefix #{install_dir}"]
+      end
+
+      # Writes all source files to the file system, returning an Array of the
+      # Pathnames created.
+      #
+      # +dir+ is the directory to write the files to. If not provided, files are
+      # written to the current directory.
+      #
+      # Header files for the project are written into a folder named 'include',
+      # which will be created if it does not exist. Other sources are written to
+      # a folder named 'src' which will also be created if it doesn't exist. The
+      # CMakeLists.txt file is written directly into +dir+.
+      def save(dir = '.')
+        dir = Pathname.new(dir) unless dir.is_a?(Pathname)
+        saved_build_sources = build_sources.map { |it| it.save(dir) }
+
+        unless @source_set.lib_headers.empty?
+          include_dir = dir.join('include')
+          Dir.mkdir(include_dir)
+          saved_headers = @source_set.lib_headers.map do |it|
+            it.save(include_dir)
+          end
+        end
+
+        unless @source_set.lib_sources.empty?
+          src_dir = dir.join('src')
+          Dir.mkdir(src_dir)
+          saved_srcs = @source_set.lib_sources.map do |it|
+            it.save(src_dir)
+          end
+        end
+
+        saved_build_sources + saved_headers + saved_srcs
       end
 
       # All source files in this project.

--- a/lib/wrapture/build/cmake_build.rb
+++ b/lib/wrapture/build/cmake_build.rb
@@ -29,6 +29,9 @@ module Wrapture
       include Build
       include SourceSet
 
+      # The root path for include files.
+      attr_accessor :include_dir
+
       # The underlying sources for the project.
       attr_reader :source_set
 
@@ -54,7 +57,8 @@ module Wrapture
       # Create a CMake build for a set of source files.
       def initialize(source_set)
         @source_set = source_set
-        @source_dir = nil
+        @include_dir = '${PROJECT_SOURCE_DIR}/include/'
+        @source_dir = '${PROJECT_SOURCE_DIR}/src/'
       end
 
       # Invocations of CMake to configure and build this project.
@@ -74,26 +78,25 @@ module Wrapture
       # information about the source files and any dependencies required.
       def cmake_lists
         file = SourceFile.new('CMakeLists.txt')
-
         file.puts('cmake_minimum_required(VERSION 3.10)')
         file.puts("project(#{@source_set.name})")
         file.puts
+        file.puts("set(#{@source_set.name.upcase}_INCLUDE_DIR")
+        file.puts("  \"#{@include_dir}\"")
+        file.puts(')')
+        file.puts
+        file.puts("set(#{@source_set.name.upcase}_SOURCE_DIR")
+        file.puts("  \"#{@source_dir}\"")
+        file.puts(')')
+        file.puts
 
-        path_prefix = if @source_dir
-                        file.puts("set(#{@source_set.name.upcase}_DIR")
-                        file.puts("  \"#{@source_dir}\"")
-                        file.puts(')')
-                        file.puts
-
-                        "${#{@source_set.name.upcase}_DIR}/"
-                      else
-                        ''
-                      end
+        include_path_prefix = "${#{@source_set.name.upcase}_INCLUDE_DIR}/"
+        src_path_prefix = "${#{@source_set.name.upcase}_SOURCE_DIR}/"
 
         header_list = "#{@source_set.name.upcase}_HEADERS"
         file.puts("set(#{header_list}")
         @source_set.lib_headers.each do |header|
-          file.puts("  \"#{path_prefix}#{header.path}\"")
+          file.puts("  \"#{include_path_prefix}#{header.path}\"")
         end
         file.puts(')')
         file.puts
@@ -102,7 +105,7 @@ module Wrapture
           source_list = "#{@source_set.name.upcase}_SOURCES"
           file.puts("set(#{source_list}")
           @source_set.lib_sources.each do |source|
-            file.puts("  \"#{path_prefix}#{source.path}\"")
+            file.puts("  \"#{src_path_prefix}#{source.path}\"")
           end
           file.puts(')')
           file.puts
@@ -127,11 +130,7 @@ module Wrapture
           file.puts("  PUBLIC #{lib_deps}")
           file.puts(')')
           file.puts("target_include_directories(#{@source_set.name}")
-          if @source_dir
-            file.puts("  PRIVATE ${#{@source_set.name.upcase}_DIR}")
-          else
-            file.puts('  PRIVATE ${PROJECT_SOURCE_DIR}')
-          end
+          file.puts("  PRIVATE #{include_path_prefix}")
           file.puts(')')
           file.puts
         end
@@ -161,25 +160,25 @@ module Wrapture
       # CMakeLists.txt file is written directly into +dir+.
       def save(dir = '.')
         dir = Pathname.new(dir) unless dir.is_a?(Pathname)
-        saved_build_sources = build_sources.map { |it| it.save(dir) }
+        saved_sources = build_sources.map { |it| it.save(dir) }
 
         unless @source_set.lib_headers.empty?
           include_dir = dir.join('include')
-          Dir.mkdir(include_dir)
-          saved_headers = @source_set.lib_headers.map do |it|
+          FileUtils.mkdir_p(include_dir)
+          saved_sources += @source_set.lib_headers.map do |it|
             it.save(include_dir)
           end
         end
 
         unless @source_set.lib_sources.empty?
           src_dir = dir.join('src')
-          Dir.mkdir(src_dir)
-          saved_srcs = @source_set.lib_sources.map do |it|
+          FileUtils.mkdir_p(src_dir)
+          saved_sources += @source_set.lib_sources.map do |it|
             it.save(src_dir)
           end
         end
 
-        saved_build_sources + saved_headers + saved_srcs
+        saved_sources
       end
 
       # All source files in this project.

--- a/lib/wrapture/build/pyproject_build.rb
+++ b/lib/wrapture/build/pyproject_build.rb
@@ -3,7 +3,7 @@
 # frozen_string_literal: true
 
 #--
-# Copyright 2025 Joel E. Anderson
+# Copyright 2025-2026 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -67,10 +67,6 @@ module Wrapture
       end
 
       # A pyproject.toml file that could be used to build this module.
-      #
-      # CMake is a common build system for C++ projects. It uses a file named
-      # CMakeLists.txt to describe how to build a project, including information
-      # about the source files and any dependencies required.
       def pyproject
         sources = @source_set.module_sources.map do |src|
           "\"#{src.path}\""

--- a/rakelib/examples.rake
+++ b/rakelib/examples.rake
@@ -24,7 +24,7 @@ def run_cpp_example(name, lib, sources, build_dir)
   Wrapture::Build::CmakeBuild.new(build).save(build_dir)
 
   Dir.chdir(build_dir) do
-    usage_opts = "-I. -I#{example_dir} -o #{lib}_usage_cpp"
+    usage_opts = "-Iinclude -I#{example_dir} -o #{lib}_usage_cpp"
 
     if sources
       source_opts = "-shared -o lib#{lib}.so -fPIC -I#{example_dir}"

--- a/sig/build/cmake_build.rbs
+++ b/sig/build/cmake_build.rbs
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2025 Joel E. Anderson
+# Copyright 2025-2026 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ module Wrapture
       def build_system_sources: -> Array[Wrapture::SourceFile]
       def cmake_lists: -> Wrapture::SourceFile
       def install_commands: (?install_dir: String) -> Array[String]
+      def save: (?(String | Pathname)) -> Array[Pathname]
       def sources: -> Enumerable[Wrapture::SourceFile]
     end
   end

--- a/sig/build/cmake_build.rbs
+++ b/sig/build/cmake_build.rbs
@@ -22,6 +22,8 @@ module Wrapture
 
       @source_set: (Wrapture::CSource::CSourceSet | Wrapture::CppSource::CppSourceSet)
 
+      attr_accessor include_dir: String
+      attr_accessor source_dir: String
       attr_reader source_set: (Wrapture::CSource::CSourceSet | Wrapture::CppSource::CppSourceSet)
 
       def self.from_hash: (spec_hash) -> Wrapture::Build::CmakeBuild

--- a/test/fixture.rb
+++ b/test/fixture.rb
@@ -2,7 +2,7 @@
 
 # frozen_string_literal: true
 
-# Copyright 2019-2025 Joel E. Anderson
+# Copyright 2019-2026 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ require 'yaml'
 # The build spec for the fixture corresponding to +name+.
 def fixture_build(name)
   build = Wrapture::Build.from_hash(fixture_build_hash(name))
+  build.include_dir = File.join(File.expand_path('fixtures', __dir__), name)
   build.source_dir = File.join(File.expand_path('fixtures', __dir__), name)
 
   build

--- a/test/unit/build/test_cmake_build.rb
+++ b/test/unit/build/test_cmake_build.rb
@@ -2,7 +2,7 @@
 
 # frozen_string_literal: true
 
-# Copyright 2025 Joel E. Anderson
+# Copyright 2025-2026 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,6 +23,36 @@ require 'minitest/autorun'
 require 'wrapture'
 
 class CmakeBuildTest < Minitest::Test
+  def test_cmake_c_build_save
+    set = Wrapture::CSource::CSourceSet.new('c_source_save_test')
+    src = Wrapture::CSource::CSourceFile.new('src.c')
+    src_comment = '// this is a test source file for saving c source sets'
+    src << src_comment
+    set.add_lib_source(src)
+    header = Wrapture::CSource::CSourceFile.new('src.h')
+    header_comment = '// this is a test header file for saving c source sets'
+    header << header_comment
+    set.add_lib_header(header)
+    build = Wrapture::Build::CmakeBuild.new(set)
+
+    Dir.mktmpdir do |dir|
+      base_path = Pathname.new(dir)
+      build.save(dir)
+      src_path = base_path.join('src', 'src.c')
+      header_path = base_path.join('include', 'src.h')
+
+      assert_path_exists(base_path.join('CMakeLists.txt'))
+      assert_path_exists(src_path)
+      assert_path_exists(header_path)
+
+      header_contents = File.read(header_path)
+      src_contents = File.read(src_path)
+
+      assert_equal(src_comment, src_contents)
+      assert_equal(header_comment, header_contents)
+    end
+  end
+
   def test_cmake_c_build_sources
     build_hash = fixture_hash('cmake_c_sources')
     build = Wrapture::Build::CmakeBuild.from_hash(build_hash)

--- a/test/unit/build/test_cmake_build.rb
+++ b/test/unit/build/test_cmake_build.rb
@@ -53,6 +53,29 @@ class CmakeBuildTest < Minitest::Test
     end
   end
 
+  def test_cmake_c_build_save_include_dir_exists
+    set = Wrapture::CSource::CSourceSet.new('c_source_save_include_exists_test')
+    header = Wrapture::CSource::CSourceFile.new('src.h')
+    header_comment = '// this is a test header file for saving c source sets'
+    header << header_comment
+    set.add_lib_header(header)
+    build = Wrapture::Build::CmakeBuild.new(set)
+
+    Dir.mktmpdir do |dir|
+      base_path = Pathname.new(dir)
+      Dir.mkdir(base_path.join('include'))
+      build.save(dir)
+      header_path = base_path.join('include', 'src.h')
+
+      assert_path_exists(base_path.join('CMakeLists.txt'))
+      assert_path_exists(header_path)
+
+      header_contents = File.read(header_path)
+
+      assert_equal(header_comment, header_contents)
+    end
+  end
+
   def test_cmake_c_build_sources
     build_hash = fixture_hash('cmake_c_sources')
     build = Wrapture::Build::CmakeBuild.from_hash(build_hash)

--- a/test/unit/c_source/test_c_source_set.rb
+++ b/test/unit/c_source/test_c_source_set.rb
@@ -2,7 +2,7 @@
 
 # frozen_string_literal: true
 
-# Copyright 2025 Joel E. Anderson
+# Copyright 2025-2026 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -44,5 +44,33 @@ class CSourceSetTest < Minitest::Test
     build = Wrapture::CSource::CSourceSet.from_hash(build_hash)
 
     assert_instance_of(Wrapture::CSource::CSourceSet, build)
+  end
+
+  def test_c_source_set_save
+    set = Wrapture::CSource::CSourceSet.new('c_source_save_test')
+    src = Wrapture::CSource::CSourceFile.new('src.c')
+    src_comment = '// this is a test source file for saving c source sets'
+    src << src_comment
+    set.add_lib_source(src)
+    header = Wrapture::CSource::CSourceFile.new('src.h')
+    header_comment = '// this is a test header file for saving c source sets'
+    header << header_comment
+    set.add_lib_header(header)
+
+    Dir.mktmpdir do |dir|
+      base_path = Pathname.new(dir)
+      set.save(dir)
+      src_path = base_path.join('src.c')
+      header_path = base_path.join('src.h')
+
+      assert_path_exists(src_path)
+      assert_path_exists(header_path)
+
+      src_contents = File.read(src_path)
+      header_contents = File.read(header_path)
+
+      assert_equal(src_comment, src_contents)
+      assert_equal(header_comment, header_contents)
+    end
   end
 end


### PR DESCRIPTION
When saving CMake builds, the source and header files are now saved into `src` and `include` folders (respectively) within the project directory, instead of in the project root.