### PR TITLE
add exports to c++ classes

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,7 +12,6 @@ fixes, check out the
 ## [0.6.0] - Unreleased
 ### Added
  - Support for Ruby 3.2 through 3.4.
- - Ruby 2.6 is no longer supported.
  - RBS signatures.
  - Python wrapper generation.
  - CMake project generation.
@@ -25,7 +24,7 @@ fixes, check out the
    all headers generated for them.
 
 ### Removed
- - Ruby 2.4 and 2.5 are no longer supported.
+ - Ruby 2.4 through 2.6 are no longer supported.
 
 ## [0.5.0] - 2020-12-15
 ### Fixed

--- a/lib/wrapture/build/cmake_build.rb
+++ b/lib/wrapture/build/cmake_build.rb
@@ -24,7 +24,9 @@ module Wrapture
   module Build
     # A CMake project that builds a library.
     #
-    # This currently supports C and C++ libraries.
+    # CMake is a common build system for C and C++ projects. It uses a file
+    # named CMakeLists.txt to describe how to build a project, including
+    # information about the source files and any dependencies required.
     class CmakeBuild
       include Build
       include SourceSet
@@ -72,16 +74,12 @@ module Wrapture
       end
 
       # A CMakeLists.txt file that could be used to build this project.
-      #
-      # CMake is a common build system for C and C++ projects. It uses a file
-      # named CMakeLists.txt to describe how to build a project, including
-      # information about the source files and any dependencies required.
       def cmake_lists
         file = SourceFile.new('CMakeLists.txt')
         file.puts('cmake_minimum_required(VERSION 3.10)')
         file.puts("project(#{@source_set.name})")
         file.puts
-        file.puts("set(#{@source_set.name.upcase}_INCLUDE_DIR")
+        file.puts("set(#{include_dir_variable}")
         file.puts("  \"#{@include_dir}\"")
         file.puts(')')
         file.puts
@@ -90,16 +88,7 @@ module Wrapture
         file.puts(')')
         file.puts
 
-        include_path_prefix = "${#{@source_set.name.upcase}_INCLUDE_DIR}/"
         src_path_prefix = "${#{@source_set.name.upcase}_SOURCE_DIR}/"
-
-        header_list = "#{@source_set.name.upcase}_HEADERS"
-        file.puts("set(#{header_list}")
-        @source_set.lib_headers.each do |header|
-          file.puts("  \"#{include_path_prefix}#{header.path}\"")
-        end
-        file.puts(')')
-        file.puts
 
         unless @source_set.lib_sources.empty?
           source_list = "#{@source_set.name.upcase}_SOURCES"
@@ -130,17 +119,44 @@ module Wrapture
           file.puts("  PUBLIC #{lib_deps}")
           file.puts(')')
           file.puts("target_include_directories(#{@source_set.name}")
-          file.puts("  PRIVATE #{include_path_prefix}")
+          target_include_directories.each do |dir|
+            file.puts("  PRIVATE \"#{dir}\"")
+          end
           file.puts(')')
           file.puts
         end
 
+        exports = @source_set.lib_headers.grep(CSource::CExportHeader)
+        unless exports.empty?
+          file.puts('include(GenerateExportHeader)')
+          exports.each do |export|
+            export_path = "${PROJECT_BINARY_DIR}/include/#{export.path}"
+            file.puts("generate_export_header(#{@source_set.name}")
+            file.puts("  BASE_NAME \"#{export.base_name}\"")
+            file.puts("  EXPORT_FILE_NAME \"#{export_path}\"")
+            file.puts(')')
+          end
+        end
+
+        header_list = "#{@source_set.name.upcase}_HEADERS"
+        file.puts("set(#{header_list}")
+        target_headers.each do |header|
+          file.puts("  \"#{header}\"")
+        end
+        file.puts(')')
+        file.puts
+
         file.puts('include(GNUInstallDirs)')
         file.puts("install(TARGETS #{@source_set.name})")
-        header_dest = 'DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}'
+        header_dest = 'DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"'
         file.puts("install(FILES ${#{header_list}} #{header_dest})")
 
         file
+      end
+
+      # The CMake variable that holds the include directory for the project.
+      def include_dir_variable
+        "#{@source_set.name.upcase}_INCLUDE_DIR"
       end
 
       # Invocations of CMake to configure and install this project.
@@ -162,10 +178,11 @@ module Wrapture
         dir = Pathname.new(dir) unless dir.is_a?(Pathname)
         saved_sources = build_sources.map { |it| it.save(dir) }
 
-        unless @source_set.lib_headers.empty?
+        headers = @source_set.lib_headers.grep_v(CSource::CExportHeader)
+        unless headers.empty?
           include_dir = dir.join('include')
           FileUtils.mkdir_p(include_dir)
-          saved_sources += @source_set.lib_headers.map do |it|
+          saved_sources += headers.map do |it|
             it.save(include_dir)
           end
         end
@@ -187,6 +204,28 @@ module Wrapture
       # project.
       def sources
         build_sources + @source_set.sources
+      end
+
+      # The headers for the library target in this project.
+      def target_headers
+        @source_set.lib_headers.map do |header|
+          if header.is_a?(CSource::CExportHeader)
+            "${PROJECT_BINARY_DIR}/include/#{header.path}"
+          else
+            "${#{include_dir_variable}}/#{header.path}"
+          end
+        end
+      end
+
+      # The include directories for the library target in this project.
+      def target_include_directories
+        dirs = [include_dir_variable]
+
+        unless @source_set.lib_headers.grep(CSource::CExportHeader).empty?
+          dirs << '${PROJECT_BINARY_DIR}/include'
+        end
+
+        dirs
       end
     end
   end

--- a/lib/wrapture/build/cmake_build.rb
+++ b/lib/wrapture/build/cmake_build.rb
@@ -75,6 +75,8 @@ module Wrapture
 
       # A CMakeLists.txt file that could be used to build this project.
       def cmake_lists
+        # TODO: pick up here, add definition of export macro to target build
+
         file = SourceFile.new('CMakeLists.txt')
         file.puts('cmake_minimum_required(VERSION 3.10)')
         file.puts("project(#{@source_set.name})")
@@ -89,6 +91,7 @@ module Wrapture
         file.puts
 
         src_path_prefix = "${#{@source_set.name.upcase}_SOURCE_DIR}/"
+        exports = @source_set.lib_headers.grep(CSource::CExportHeader)
 
         unless @source_set.lib_sources.empty?
           source_list = "#{@source_set.name.upcase}_SOURCES"
@@ -123,10 +126,18 @@ module Wrapture
             file.puts("  PRIVATE \"#{dir}\"")
           end
           file.puts(')')
+
+          unless exports.empty?
+            file.puts("target_compile_definitions(#{@source_set.name}")
+            exports.each do |export|
+              file.puts("  PRIVATE #{export.base_name}_EXPORTING=1")
+            end
+            file.puts(')')
+          end
+
           file.puts
         end
 
-        exports = @source_set.lib_headers.grep(CSource::CExportHeader)
         unless exports.empty?
           file.puts('include(GenerateExportHeader)')
           exports.each do |export|

--- a/lib/wrapture/build/cmake_build.rb
+++ b/lib/wrapture/build/cmake_build.rb
@@ -75,8 +75,6 @@ module Wrapture
 
       # A CMakeLists.txt file that could be used to build this project.
       def cmake_lists
-        # TODO: pick up here, add definition of export macro to target build
-
         file = SourceFile.new('CMakeLists.txt')
         file.puts('cmake_minimum_required(VERSION 3.10)')
         file.puts("project(#{@source_set.name})")
@@ -138,31 +136,23 @@ module Wrapture
           file.puts
         end
 
-        unless exports.empty?
-          file.puts('include(GenerateExportHeader)')
-          exports.each do |export|
-            export_path = "${PROJECT_BINARY_DIR}/include/#{export.path}"
-            file.puts("generate_export_header(#{@source_set.name}")
-            file.puts("  BASE_NAME \"#{export.base_name}\"")
-            file.puts("  EXPORT_FILE_NAME \"#{export_path}\"")
-            file.puts(')')
-          end
-        end
+        cmake_lists_generate_export_header_lines.each { |it| file.puts(it) }
 
-        header_list = "#{@source_set.name.upcase}_HEADERS"
-        file.puts("set(#{header_list}")
+        file.puts("set(#{headers_variable}")
         target_headers.each do |header|
           file.puts("  \"#{header}\"")
         end
         file.puts(')')
         file.puts
 
-        file.puts('include(GNUInstallDirs)')
-        file.puts("install(TARGETS #{@source_set.name})")
-        header_dest = 'DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"'
-        file.puts("install(FILES ${#{header_list}} #{header_dest})")
+        cmake_lists_target_install_lines.each { |it| file.puts(it) }
 
         file
+      end
+
+      # The CMake variable that holds the public headers for the library.
+      def headers_variable
+        "#{@source_set.name.upcase}_HEADERS"
       end
 
       # The CMake variable that holds the include directory for the project.
@@ -237,6 +227,37 @@ module Wrapture
         end
 
         dirs
+      end
+
+      private
+
+      # Lines of CMake code to generate the export headers for the library,
+      # without line endings.
+      def cmake_lists_generate_export_header_lines
+        exports = @source_set.lib_headers.grep(CSource::CExportHeader)
+
+        return [] if exports.empty?
+
+        lines = ['include(GenerateExportHeader)']
+
+        exports.each do |export|
+          export_path = "${PROJECT_BINARY_DIR}/include/#{export.path}"
+          lines << "generate_export_header(#{@source_set.name}"
+          lines << "  BASE_NAME \"#{export.base_name}\""
+          lines << "  EXPORT_FILE_NAME \"#{export_path}\""
+          lines << ')'
+        end
+
+        lines
+      end
+
+      # Lines of CMake code to install the library target, without line endings.
+      def cmake_lists_target_install_lines
+        header_dest = 'DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"'
+
+        ['include(GNUInstallDirs)',
+         "install(TARGETS #{@source_set.name})",
+         "install(FILES ${#{headers_variable}} #{header_dest})"]
       end
     end
   end

--- a/lib/wrapture/build/cmake_build.rb
+++ b/lib/wrapture/build/cmake_build.rb
@@ -25,7 +25,7 @@ module Wrapture
     # A CMake project that builds a library.
     #
     # CMake is a common build system for C and C++ projects. It uses a file
-    # named CMakeLists.txt to describe how to build a project, including
+    # named +CMakeLists.txt+ to describe how to build a project, including
     # information about the source files and any dependencies required.
     class CmakeBuild
       include Build

--- a/lib/wrapture/c_source.rb
+++ b/lib/wrapture/c_source.rb
@@ -20,6 +20,7 @@
 
 require 'wrapture/c_source/c_block'
 require 'wrapture/c_source/c_declaration'
+require 'wrapture/c_source/c_export_header'
 require 'wrapture/c_source/c_expression'
 require 'wrapture/c_source/c_function'
 require 'wrapture/c_source/c_if'

--- a/lib/wrapture/c_source/c_export_header.rb
+++ b/lib/wrapture/c_source/c_export_header.rb
@@ -47,7 +47,11 @@ module Wrapture
 
       # An export header name derived from a +Named+ +spec+.
       def self.export_header_name(spec)
-        "#{spec.snake_case_name}_export.h"
+        if spec.name_words.empty?
+          'export.h'
+        else
+          "#{spec.snake_case_name}_export.h"
+        end
       end
 
       # A fully-defined export header for a +Named+ +spec+.
@@ -60,10 +64,14 @@ module Wrapture
       # used by the Microsoft C compiler: see
       # {the Microsoft Learn article}[https://learn.microsoft.com/en-us/cpp/build/importing-into-an-application-using-declspec-dllimport]
       # for more information.
-      def self.from_spec(spec)
-        header_name = export_header_name(spec)
+      def self.from_spec(spec, path: nil)
+        header_name = if path.nil?
+                        export_header_name(spec)
+                      else
+                        path
+                      end
         base_name = base_name(spec)
-        guard = "#{header_name.upcase.delete_suffix('.H')}_H"
+        guard = header_name.upcase.gsub('.', '_')
         header = new(header_name, base_name)
 
         content = <<~HEADER_CONTENT
@@ -73,7 +81,7 @@ module Wrapture
           #ifdef _WIN32
           #  ifdef #{base_name}_EXPORTING
           #    define #{base_name}_EXPORT __declspec(dllexport)
-          #  else')
+          #  else
           #    define #{base_name}_EXPORT __declspec(dllimport)
           #  endif
           #else

--- a/lib/wrapture/c_source/c_export_header.rb
+++ b/lib/wrapture/c_source/c_export_header.rb
@@ -78,6 +78,19 @@ module Wrapture
           #ifndef #{guard}
           #define #{guard}
 
+          /**
+           * @file #{header_name}
+           * @brief An export header for #{base_name}.
+           * This header defines the macro that is used in public headers that
+           * make their contents available for external use.
+           */
+
+          /**
+           * @def #{base_name}_EXPORT
+           * An attribute that designates that a class or function should be
+           * available to users of this library.
+           */
+
           #ifdef _WIN32
           #  ifdef #{base_name}_EXPORTING
           #    define #{base_name}_EXPORT __declspec(dllexport)

--- a/lib/wrapture/c_source/c_export_header.rb
+++ b/lib/wrapture/c_source/c_export_header.rb
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# frozen_string_literal: true
+
+#--
+# Copyright 2026 Joel E. Anderson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#++
+
+require 'wrapture/c_source/c_source_file'
+
+module Wrapture
+  module CSource
+    # A header file that defines export macros for public functions.
+    #
+    # Exposing functions in C libraries differs between build toolchains. One
+    # of the most common examples is the difference between the Microsoft
+    # compiler, which uses +__declspec(dllexport)+ to designate a function as
+    # exported in a DLL, and GCC which uses
+    # +__attribute__ ((visibility ("default")))+ to mark a function as visible
+    # in the resulting shared library.
+    #
+    # An export header defines one or more macros that can be used in library
+    # headers, which expand to the appropriate visibility incantation based on
+    # the toolchain they are used from.
+    #
+    # This is a separate source file class because some build systems, including
+    # CMake, can generate these headers on their own. In those cases, a source
+    # file set's export header can be filtered out, and the build system can
+    # generate its own instead.
+    class CExportHeader < CSourceFile
+      # A base name to use for a +Named+ +spec+.
+      def self.base_name(spec)
+        spec.screaming_snake_case_name
+      end
+
+      # An export header name derived from a +Named+ +spec+.
+      def self.export_header_name(spec)
+        "#{spec.snake_case_name}_export.h"
+      end
+
+      # A fully-defined export header for a +Named+ +spec+.
+      #
+      # The export macro will be +CExportHeader.base_name+ with "_EXPORT"
+      # added to the end. This macro will be defined to depend on whether a
+      # similar symbol but with a suffix of "_EXPORTING" instead, which will
+      # signify that the library is being built instead of used. This is
+      # necessary in order to properly support the dllimport/dllexport semantics
+      # used by the Microsoft C compiler: see
+      # {the Microsoft Learn article}[https://learn.microsoft.com/en-us/cpp/build/importing-into-an-application-using-declspec-dllimport]
+      # for more information.
+      def self.from_spec(spec)
+        header_name = export_header_name(spec)
+        base_name = base_name(spec)
+        guard = "#{header_name.upcase.delete_suffix('.H')}_H"
+        header = new(header_name, base_name)
+
+        content = <<~HEADER_CONTENT
+          #ifndef #{guard}
+          #define #{guard}
+
+          #ifdef _WIN32
+          #  ifdef #{base_name}_EXPORTING
+          #    define #{base_name}_EXPORT __declspec(dllexport)
+          #  else')
+          #    define #{base_name}_EXPORT __declspec(dllimport)
+          #  endif
+          #else
+          #  define #{base_name}_EXPORT __attribute__((visibility("default")))
+          #endif
+
+          #endif /* #{guard} */
+        HEADER_CONTENT
+
+        header.puts(content)
+
+        header
+      end
+
+      # An export header has a file name, as well as a base name that is used
+      # to derive the export macros defined in the file.
+      def initialize(path, base_name)
+        super(path)
+        @base_name = base_name
+      end
+
+      # The base name used to derive the export macro names.
+      attr_reader :base_name
+    end
+  end
+end

--- a/lib/wrapture/c_source/c_export_header.rb
+++ b/lib/wrapture/c_source/c_export_header.rb
@@ -26,20 +26,23 @@ module Wrapture
     #
     # Exposing functions in C libraries differs between build toolchains. One
     # of the most common examples is the difference between the Microsoft
-    # compiler, which uses +__declspec(dllexport)+ to designate a function as
-    # exported in a DLL, and GCC which uses
-    # +__attribute__ ((visibility ("default")))+ to mark a function as visible
-    # in the resulting shared library.
+    # compiler, which uses <tt>__declspec(dllexport)</tt> to designate a
+    # function as exported in a DLL, and GCC which uses
+    # <tt>__attribute__ ((visibility ("default")))</tt> to mark a function as
+    # visible in the resulting shared library.
     #
     # An export header defines one or more macros that can be used in library
     # headers, which expand to the appropriate visibility incantation based on
     # the toolchain they are used from.
     #
-    # This is a separate source file class because some build systems, including
-    # CMake, can generate these headers on their own. In those cases, a source
-    # file set's export header can be filtered out, and the build system can
-    # generate its own instead.
+    # This is a separate source file class because some build systems, such as
+    # +Build::CmakeBuild+, can generate these headers on their own. In those
+    # cases, a source file set's export header can be filtered out, and the
+    # build system can generate its own instead.
     class CExportHeader < CSourceFile
+      # The base name used to derive the export macro names.
+      attr_reader :base_name
+
       # A base name to use for a +Named+ +spec+.
       def self.base_name(spec)
         spec.screaming_snake_case_name
@@ -57,8 +60,8 @@ module Wrapture
       # A fully-defined export header for a +Named+ +spec+.
       #
       # The export macro will be +CExportHeader.base_name+ with "_EXPORT"
-      # added to the end. This macro will be defined to depend on whether a
-      # similar symbol but with a suffix of "_EXPORTING" instead, which will
+      # added to the end. This macro will be defined differently depending on
+      # if a similar symbol with a suffix of "_EXPORTING" is defined, which will
       # signify that the library is being built instead of used. This is
       # necessary in order to properly support the dllimport/dllexport semantics
       # used by the Microsoft C compiler: see
@@ -109,15 +112,12 @@ module Wrapture
         header
       end
 
-      # An export header has a file name, as well as a base name that is used
-      # to derive the export macros defined in the file.
+      # An export header has a +path+, as well as a +base_name+ that is used
+      # to derive the name of the export macros defined in the header.
       def initialize(path, base_name)
         super(path)
         @base_name = base_name
       end
-
-      # The base name used to derive the export macro names.
-      attr_reader :base_name
     end
   end
 end

--- a/lib/wrapture/c_source/c_source_file.rb
+++ b/lib/wrapture/c_source/c_source_file.rb
@@ -3,7 +3,7 @@
 # frozen_string_literal: true
 
 #--
-# Copyright 2025 Joel E. Anderson
+# Copyright 2025-2026 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ module Wrapture
 
       # The includes used within this source file.
       def includes
-        @tree.select { |it| it.is_a?(CInclude) }
+        @tree.grep(CInclude)
       end
     end
   end

--- a/lib/wrapture/cpp_source.rb
+++ b/lib/wrapture/cpp_source.rb
@@ -41,6 +41,9 @@ module Wrapture
       src = []
       src += format_doxygen(cls.doc) unless cls.doc.empty?
       src << 'class '
+      cls.attributes.each do |it|
+        src << "#{it} "
+      end
       src << cls.name
       src << " : public #{cls.parent_name}" unless cls.parent_name.nil?
       src << " {\npublic:\n"

--- a/lib/wrapture/cpp_source/cpp_class.rb
+++ b/lib/wrapture/cpp_source/cpp_class.rb
@@ -22,6 +22,9 @@ module Wrapture
   module CppSource
     # A class used in C++ code.
     class CppClass
+      # Class attributes.
+      attr_reader :attributes
+
       # Class constants.
       attr_reader :constants
 
@@ -53,6 +56,7 @@ module Wrapture
 
       # A C++ class must have a name, at a minimum.
       def initialize(name)
+        @attributes = []
         @constants = []
         @constructors = []
         @data_members = []

--- a/lib/wrapture/cpp_source/cpp_source_file.rb
+++ b/lib/wrapture/cpp_source/cpp_source_file.rb
@@ -3,7 +3,7 @@
 # frozen_string_literal: true
 
 #--
-# Copyright 2025 Joel E. Anderson
+# Copyright 2025-2026 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ module Wrapture
 
       # The includes used within this source file.
       def includes
-        @tree.select { |it| it.is_a?(CSource::CInclude) }
+        @tree.grep(CSource::CInclude)
       end
     end
   end

--- a/lib/wrapture/wrapper/c_to_cpp.rb
+++ b/lib/wrapture/wrapper/c_to_cpp.rb
@@ -872,6 +872,7 @@ module Wrapture
         end
 
         source_set.add_lib_header(scope_header(scope))
+        source_set.add_lib_header(CSource::CExportHeader.from_spec(scope))
 
         source_set
       end

--- a/lib/wrapture/wrapper/c_to_cpp.rb
+++ b/lib/wrapture/wrapper/c_to_cpp.rb
@@ -149,8 +149,8 @@ module Wrapture
       # wrapped functions and invoking error handling are not needed for the
       # declaration. Additional C++ includes may also be present to bring in
       # type declarations for parameters declared by Wrapture.
-      def self.declaration_includes(class_spec)
-        includes = []
+      def self.declaration_includes(class_spec, scope)
+        includes = ["#{CSource::CExportHeader.export_header_name(scope)}pp"]
 
         includes.concat(class_spec[:c].includes) if class_spec.wrapped.key?(:c)
 
@@ -179,7 +179,8 @@ module Wrapture
         includes.uniq
       end
 
-      # Generate a source file with the declaration of a class.
+      # Generate a source file with the declaration of a class within a given
+      # context +scope+.
       def self.declare_class(class_spec, scope)
         src = CppSource::CppSourceFile.new(header_name(class_spec))
 
@@ -188,20 +189,15 @@ module Wrapture
         src.puts("#define #{guard}")
         src.puts
 
-        declaration_includes(class_spec).sort.each do |inc|
+        declaration_includes(class_spec, scope).sort.each do |inc|
           src << CSource::CInclude.new(inc)
         end
 
-        namespace_words = if scope.decorate_wrapped_name?
-                            Cpp.decorate_name_words(scope.name_words)
-                          else
-                            scope.name_words
-                          end
-        namespace = Named.snake_case_name(namespace_words)
+        namespace = scope_namespace(scope)
         src.puts("namespace #{namespace} {")
         src.puts
 
-        src.declare(defined_class_from_spec(class_spec))
+        src.declare(defined_class_from_spec(class_spec, scope))
 
         src.puts
         src.puts("} /* namespace #{namespace} */")
@@ -348,23 +344,17 @@ module Wrapture
           raise UndefinableSpec, "#{class_spec.name} is not definable"
         end
 
-        namespace_words = if scope.decorate_wrapped_name?
-                            Cpp.decorate_name_words(scope.name_words)
-                          else
-                            scope.name_words
-                          end
-        namespace = Named.snake_case_name(namespace_words)
-
+        namespace = scope_namespace(scope)
         src = CppSource::CppSourceFile.new("#{class_spec.name}.cpp")
 
-        definition_includes(class_spec).sort.each do |inc|
+        definition_includes(class_spec, scope).sort.each do |inc|
           src << CSource::CInclude.new(inc)
         end
 
         src.puts("namespace #{namespace} {")
         src.puts
 
-        src << defined_class_from_spec(class_spec)
+        src << defined_class_from_spec(class_spec, scope)
 
         src.puts
         src.puts("} /* namespace #{namespace} */")
@@ -385,12 +375,7 @@ module Wrapture
           src << CSource::CInclude.new(inc)
         end
 
-        namespace_words = if scope.decorate_wrapped_name?
-                            Cpp.decorate_name_words(scope.name_words)
-                          else
-                            scope.name_words
-                          end
-        namespace = Named.snake_case_name(namespace_words)
+        namespace = scope_namespace(scope)
 
         src.puts("namespace #{namespace} {")
         src.puts
@@ -406,8 +391,8 @@ module Wrapture
       end
 
       # Creates a CppClass instance from a ClassSpec, with all members and
-      # functions fully defined.
-      def self.defined_class_from_spec(spec)
+      # functions fully defined, in the given +scope+.
+      def self.defined_class_from_spec(spec, scope)
         # start with the type class, then build out the definitions
         cls = type_class_from_spec(spec)
         cls.doc = spec.doc
@@ -456,6 +441,8 @@ module Wrapture
           cls.member_functions << factory_member_function(spec)
         end
 
+        cls.attributes << "#{CSource::CExportHeader.base_name(scope)}_EXPORT"
+
         cls
       end
 
@@ -470,10 +457,11 @@ module Wrapture
         end
       end
 
-      # The includes needed in the definition file for the given class spec.
-      def self.definition_includes(class_spec)
+      # The includes needed in the definition file for the given +class_spec+ in
+      # the given +scope+.
+      def self.definition_includes(class_spec, scope)
         inc = [declaration_filename(class_spec)]
-        inc.concat(declaration_includes(class_spec))
+        inc.concat(declaration_includes(class_spec, scope))
         inc.concat(C.includes(class_spec))
 
         if C.factory?(class_spec, class_spec.scope)
@@ -805,6 +793,18 @@ module Wrapture
         header
       end
 
+      # The namespace words of a +scope+ that classes and enums within it are a
+      # part of.
+      def self.scope_namespace(scope)
+        words = if scope.decorate_wrapped_name?
+                  Cpp.decorate_name_words(scope.name_words)
+                else
+                  scope.name_words
+                end
+
+        Named.snake_case_name(words)
+      end
+
       # Creates a CppClass instance from a ClassSpec, with enough information
       # available to use the class for type conversions.
       def self.type_class_from_spec(spec)
@@ -872,7 +872,10 @@ module Wrapture
         end
 
         source_set.add_lib_header(scope_header(scope))
-        source_set.add_lib_header(CSource::CExportHeader.from_spec(scope))
+
+        export_name = "#{CSource::CExportHeader.export_header_name(scope)}pp"
+        export = CSource::CExportHeader.from_spec(scope, path: export_name)
+        source_set.add_lib_header(export)
 
         source_set
       end

--- a/sig/build/cmake_build.rbs
+++ b/sig/build/cmake_build.rbs
@@ -32,12 +32,18 @@ module Wrapture
       def build_commands: -> Array[String]
       def build_system_sources: -> Array[Wrapture::SourceFile]
       def cmake_lists: -> Wrapture::SourceFile
+      def headers_variable: -> String
       def include_dir_variable: -> String
       def install_commands: (?install_dir: String) -> Array[String]
       def save: (?(String | Pathname)) -> Array[Pathname]
       def sources: -> Enumerable[Wrapture::SourceFile]
       def target_headers: -> Array[String]
       def target_include_directories: -> Array[String]
+
+      private
+
+      def cmake_lists_generate_export_header_lines: -> Array[String]
+      def cmake_lists_target_install_lines: -> Array[String]
     end
   end
 end

--- a/sig/build/cmake_build.rbs
+++ b/sig/build/cmake_build.rbs
@@ -32,9 +32,12 @@ module Wrapture
       def build_commands: -> Array[String]
       def build_system_sources: -> Array[Wrapture::SourceFile]
       def cmake_lists: -> Wrapture::SourceFile
+      def include_dir_variable: -> String
       def install_commands: (?install_dir: String) -> Array[String]
       def save: (?(String | Pathname)) -> Array[Pathname]
       def sources: -> Enumerable[Wrapture::SourceFile]
+      def target_headers: -> Array[String]
+      def target_include_directories: -> Array[String]
     end
   end
 end

--- a/sig/c_source/c_export_header.rbs
+++ b/sig/c_source/c_export_header.rbs
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2026 Joel E. Anderson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Wrapture
+  module CSource
+    class CExportHeader < CSourceFile
+      @base_name: String
+
+      def self.base_name: (Named) -> String
+      def self.export_header_name: (Named) -> String
+      def self.from_spec: (Named) -> CExportHeader
+
+      def initialize: ((Pathname | String), String) -> void
+      attr_reader base_name: String
+    end
+  end
+end

--- a/sig/wrapper/c_to_cpp.rbs
+++ b/sig/wrapper/c_to_cpp.rbs
@@ -20,7 +20,6 @@ module Wrapture
       extend Wrapper
 
       def self.ancestor_suffix: (Wrapture::ClassSpec) -> String
-      def self.defined_class_from_spec: (Wrapture::ClassSpec) -> Wrapture::CppSource::CppClass
       def self.converter: (untyped, untyped, untyped) -> Proc
       def self.declaration_filename: (untyped) -> String
       def self.declaration_includes: (Wrapture::ClassSpec) -> Array[String]
@@ -30,6 +29,7 @@ module Wrapture
       def self.define_class: (Wrapture::ClassSpec, Wrapture::Scope) -> Wrapture::SourceFile
       def self.define_constructor: (Wrapture::ClassSpec, Wrapture::FunctionSpec) -> Wrapture::CppSource::CppFunction
       def self.define_enum: (Wrapture::ClassSpec, Wrapture::Scope) -> Wrapture::SourceFile
+      def self.defined_class_from_spec: (Wrapture::ClassSpec, Wrapture::Scope) -> Wrapture::CppSource::CppClass
       def self.definition_filename: (Wrapture::ClassSpec | Wrapture::EnumSpec) -> String
       def self.definition_includes: (Wrapture::ClassSpec | Wrapture::EnumSpec) -> Array[String]
       def self.enum_from_spec: (Wrapture::EnumSpec) -> Wrapture::CppSource::CppEnum
@@ -45,6 +45,7 @@ module Wrapture
       def self.pointer_move_constructor: (Wrapture::ClassSpec) -> Wrapture::CppSource::CppFunction
       def self.resolve_wrapped_param: (Wrapture::FunctionSpec, Wrapture::CSource::CDeclaration) -> String
       def self.scope_headers: (Wrapture::Scope) -> Wrapture::CppSource::CppSourceFile
+      def self.scope_namespace: (Wrapture::Scope) -> String
       def self.type_class_from_spec: (Wrapture::ClassSpec) -> Wrapture::CppSource::CppClass
       def self.wrap_class: (Wrapture::ClassSpec, ?Wrapture::Scope) -> Wrapture::CppSource::CppSourceSet
       def self.wrap_enum: (Wrapture::EnumSpec, ?Wrapture::Scope) -> Wrapture::CppSource::CppSourceSet

--- a/test/fixtures/versioned_class.yml
+++ b/test/fixtures/versioned_class.yml
@@ -1,5 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2026 Joel E. Anderson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: "MinimalClass"
-version: "0.2.0"
+version: "0.6.0"
 namespace: "wrapture_test"
-equivalent-struct:
-  name: "minimal_struct"
+wrapped:
+  c:
+    name: "minimal_struct"

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -70,8 +70,10 @@ end
 def count_matches(filename, regex)
   count = 0
 
-  File.open(filename).each do |line|
-    count += 1 if line.match(regex)
+  File.open(filename) do |file|
+    file.each do |line|
+      count += 1 if line.match(regex)
+    end
   end
 
   count
@@ -88,8 +90,10 @@ def count_source_file_matches(source_file, regex)
 end
 
 def file_contains_match?(filename, regex)
-  File.open(filename).each do |line|
-    return true if line.match(regex)
+  File.open(filename) do |file|
+    file.each do |line|
+      return true if line.match(regex)
+    end
   end
 
   false
@@ -97,9 +101,11 @@ end
 
 def get_include_list(filename)
   includes = []
-  File.open(filename).each do |line|
-    if (m = line.match(/#\s*include\s*["<](.*)[">]/))
-      includes << m[1]
+  File.open(filename) do |file|
+    file.each do |line|
+      if (m = line.match(/#\s*include\s*["<](.*)[">]/))
+        includes << m[1]
+      end
     end
   end
 
@@ -239,21 +245,23 @@ def validate_indentation(filename)
   line_number = 0
   indent_level = 0
 
-  File.open(filename).each do |line|
-    line_number += 1
+  File.open(filename) do |file|
+    file.each do |line|
+      line_number += 1
 
-    next if line.strip.empty?
+      next if line.strip.empty?
 
-    line.chomp!
+      line.chomp!
 
-    indent_level -= 1 if line.end_with?('}', '};') ||
-                         line.include?('} if') ||
-                         line.include?('} else')
+      indent_level -= 1 if line.end_with?('}', '};') ||
+                           line.include?('} if') ||
+                           line.include?('} else')
 
-    msg_prefix = "#{filename}: line #{line_number}"
-    validate_space_count(line, indent_level, msg_prefix)
+      msg_prefix = "#{filename}: line #{line_number}"
+      validate_space_count(line, indent_level, msg_prefix)
 
-    indent_level += 1 if line.end_with?('{')
+      indent_level += 1 if line.end_with?('{')
+    end
   end
 end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -90,13 +90,13 @@ def count_source_file_matches(source_file, regex)
 end
 
 def file_contains_match?(filename, regex)
+  result = false
+
   File.open(filename) do |file|
-    file.each do |line|
-      return true if line.match(regex)
-    end
+    result = file.any? { |line| line.match(regex) }
   end
 
-  false
+  result
 end
 
 def get_include_list(filename)

--- a/test/unit/build/test_cmake_build.rb
+++ b/test/unit/build/test_cmake_build.rb
@@ -111,5 +111,24 @@ class CmakeBuildTest < Minitest::Test
                                        'include\(GenerateExportHeader\)'))
     assert(source_file_contains_match?(cmake_lists,
                                        'BASE_NAME "TEST_BASE_NAME"'))
+    refute(source_file_contains_match?(cmake_lists, 'TEST_BASE_NAME_EXPORTING'))
+  end
+
+  def test_cmakelists_for_export_header_and_sources
+    source = Wrapture::CSource::CSourceFile.new('test_export.c')
+    export = Wrapture::CSource::CExportHeader.new('test_export.h',
+                                                  'TEST_BASE_NAME')
+    source_set = Wrapture::CSource::CSourceSet.new('test_export_lib')
+    source_set.add_lib_header(export)
+    source_set.add_lib_source(source)
+    build = Wrapture::Build::CmakeBuild.new(source_set)
+    cmake_lists = build.cmake_lists
+
+    assert_instance_of(Wrapture::SourceFile, cmake_lists)
+    assert(source_file_contains_match?(cmake_lists,
+                                       'include\(GenerateExportHeader\)'))
+    assert(source_file_contains_match?(cmake_lists,
+                                       'BASE_NAME "TEST_BASE_NAME"'))
+    assert(source_file_contains_match?(cmake_lists, 'TEST_BASE_NAME_EXPORTING'))
   end
 end

--- a/test/unit/build/test_cmake_build.rb
+++ b/test/unit/build/test_cmake_build.rb
@@ -97,4 +97,19 @@ class CmakeBuildTest < Minitest::Test
     assert(cmake_lists.contents.any? { |it| it.include?('cmakeclib.c') })
     assert(cmake_lists.contents.any? { |it| it.include?('cmakeclib.h') })
   end
+
+  def test_cmakelists_for_export_header
+    export = Wrapture::CSource::CExportHeader.new('test_export.h',
+                                                  'TEST_BASE_NAME')
+    source_set = Wrapture::CSource::CSourceSet.new('test_export_lib')
+    source_set.add_lib_header(export)
+    build = Wrapture::Build::CmakeBuild.new(source_set)
+    cmake_lists = build.cmake_lists
+
+    assert_instance_of(Wrapture::SourceFile, cmake_lists)
+    assert(source_file_contains_match?(cmake_lists,
+                                       'include\(GenerateExportHeader\)'))
+    assert(source_file_contains_match?(cmake_lists,
+                                       'BASE_NAME "TEST_BASE_NAME"'))
+  end
 end

--- a/test/unit/c_source/test_c_export_header.rb
+++ b/test/unit/c_source/test_c_export_header.rb
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+# frozen_string_literal: true
+
 # Copyright 2026 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,17 +16,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-module Wrapture
-  module CSource
-    class CExportHeader < CSourceFile
-      @base_name: String
+require 'helper'
 
-      def self.base_name: (Named) -> String
-      def self.export_header_name: (Named) -> String
-      def self.from_spec: (Named, ?path: (Pathname | String)) -> CExportHeader
+require 'fixture'
+require 'minitest/autorun'
+require 'wrapture'
 
-      def initialize: ((Pathname | String), String) -> void
-      attr_reader base_name: String
-    end
+class CExportHeaderTest < Minitest::Test
+  def test_export_header_name_with_empty_name
+    scope = Wrapture::Scope.new
+    name = Wrapture::CSource::CExportHeader.export_header_name(scope)
+
+    refute(name.start_with?('_'),
+           'export header name starts with underscore for an empty name')
   end
 end

--- a/test/unit/test_scope.rb
+++ b/test/unit/test_scope.rb
@@ -39,9 +39,6 @@ class ScopeTest < Minitest::Test
     assert_equal(test_spec[:classes].count, scope.classes.count)
     assert_equal(0, scope.enums.count)
 
-    build = Wrapture::Wrapper::CToCpp.wrap_scope(scope)
-
-    assert_equal(scope.classes.count, build.sources.count / 2)
     assert_equal('wrapture_test', scope.name)
   end
 
@@ -51,10 +48,6 @@ class ScopeTest < Minitest::Test
 
     assert_equal(test_spec[:classes].count, scope.classes.count)
     assert_equal(0, scope.enums.count)
-
-    build = Wrapture::Wrapper::CToCpp.wrap_scope(scope)
-
-    assert_equal(scope.classes.count, build.sources.count / 2)
   end
 
   def test_templatized_classes
@@ -119,6 +112,5 @@ class ScopeTest < Minitest::Test
     validate_cpp_build(scope, build)
 
     assert_equal(test_spec[:classes].count, scope.classes.count)
-    assert_equal(scope.classes.count, build.sources.count / 2)
   end
 end

--- a/test/unit/test_wrapper.rb
+++ b/test/unit/test_wrapper.rb
@@ -2,7 +2,7 @@
 
 # frozen_string_literal: true
 
-# Copyright 2019-2025 Joel E. Anderson
+# Copyright 2019-2026 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ require 'helper'
 require 'minitest/autorun'
 require 'wrapture'
 
+# rubocop:disable Style/OneClassPerFile -- simple modules for testing
 module WToX
   extend Wrapture::Wrapper
 end
@@ -138,4 +139,6 @@ class WrapperTest < Minitest::Test
       end
     end
   end
+
+  # rubocop:enable Style/OneClassPerFile
 end

--- a/test/unit/wrapper/test_c_to_cpp.rb
+++ b/test/unit/wrapper/test_c_to_cpp.rb
@@ -58,10 +58,13 @@ class CToCppTest < Minitest::Test
   def test_declaration_includes_with_no_c_details
     # we need a class spec where there isn't a :c key in wrapped
     class_spec = Wrapture::ClassSpec.new(fixture_hash('versioned_class'))
+    scope = Wrapture::Scope.new({ name: ['test'] })
+    includes = Wrapture::Wrapper::CToCpp.declaration_includes(class_spec, scope)
 
-    assert_empty(Wrapture::Wrapper::CToCpp.declaration_includes(class_spec),
-                 'declaration includes not empty for a class spec with no ' \
-                 'entry for c in the wrapped languages')
+    assert_equal(1, includes.length,
+                 'declaration includes has more than export header for a  ' \
+                 'class spec with no entry for c in the wrapped languages')
+    assert(includes.first.end_with?('export.hpp'))
   end
 
   def test_delegating_constructor

--- a/test/unit/wrapper/test_c_to_cpp.rb
+++ b/test/unit/wrapper/test_c_to_cpp.rb
@@ -287,8 +287,8 @@ class CToCppTest < Minitest::Test
 
     validate_cpp_build(scope, build)
 
-    # 2 headers per class, one per enum, and the rollup header
-    expected_count = (scope.classes.count * 2) + scope.enums.count + 1
+    # 2 headers per class, one per enum, and the rollup and export headers
+    expected_count = (scope.classes.count * 2) + scope.enums.count + 2
 
     assert_equal(expected_count, build.sources.count)
   end


### PR DESCRIPTION
C++ classes must be generated with a visibility attribute in some environments, which instructs the build toolchain to make the class visible in the resulting library. This change adds this functionality, and also uses CMake's GenerateExportHeader module for CMake projects to generate the macros which define the exact attributes to add to the class.