### PR TITLE
rename wrapped to source

### DIFF
--- a/docs/examples/basic/stove.yml
+++ b/docs/examples/basic/stove.yml
@@ -20,7 +20,7 @@ classes:
     doc: "A humble stove."
     namespace: "kitchen"
     libraries: "stove"
-    wrapped:
+    source:
       c:
         pointer:
           name: "stove"
@@ -29,7 +29,7 @@ classes:
       name: "stove"
     constructors:
       - doc: "Creates a new stove."
-        wrapped:
+        source:
           c:
             name: "new_stove"
             params:
@@ -38,7 +38,7 @@ classes:
             return:
               type: "equivalent_struct_pointer"
     destructor:
-      wrapped:
+      source:
         c:
           name: "destroy_stove"
           params:
@@ -48,7 +48,7 @@ classes:
         doc: "Returns the number of burners on this stove."
         return:
           type: "int"
-        wrapped:
+        source:
           c:
             name: "get_burner_count"
             params:
@@ -58,7 +58,7 @@ classes:
       - name: "GetOvenTemp"
         return:
           type: "int"
-        wrapped:
+        source:
           c:
             name: "get_oven_temp"
             params:
@@ -69,7 +69,7 @@ classes:
         params:
           - name: "new_temp"
             type: "int"
-        wrapped:
+        source:
           c:
             name: "set_oven_temp"
             params:
@@ -81,7 +81,7 @@ classes:
             type: "int"
         return:
           type: "int"
-        wrapped:
+        source:
           c:
             name: "get_burner_level"
             params:
@@ -95,7 +95,7 @@ classes:
             type: "int"
           - name: "new_level"
             type: "int"
-        wrapped:
+        source:
           c:
             name: "set_burner_level"
             params:
@@ -109,7 +109,7 @@ classes:
         params:
           - name: "model"
             type: "int"
-        wrapped:
+        source:
           c:
             name: "is_model_supported"
             params:

--- a/docs/examples/constants/vcr.yml
+++ b/docs/examples/constants/vcr.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2025 Joel E. Anderson
+# Copyright 2025-2026 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ classes:
   - name: "Vcr"
     namespace: "mediacenter"
     libraries: "vcr"
-    wrapped:
+    source:
       c:
         name: "vcr"
         members:
@@ -54,7 +54,7 @@ classes:
             type: "int"
         return:
           type: "int"
-        wrapped:
+        source:
           c:
             name: "send_command"
             params:

--- a/docs/examples/enumerations/fruit.yml
+++ b/docs/examples/enumerations/fruit.yml
@@ -18,7 +18,7 @@ enums:
   - name: "Fruit"
     doc: "fruits sold by our fine establishment"
     namespace: "store"
-    wrapped:
+    source:
       c:
         includes:
           - "citrus_mangiamo.h"
@@ -30,41 +30,41 @@ enums:
         doc: "both dried and fresh!"
       - name: "banana"
         doc: "the peel is useful in car chases"
-        wrapped:
+        source:
           c:
             value: "DESIRE_BANANA"
       - name: "grape"
         doc: "you have to buy more than one though"
-        wrapped:
+        source:
           c:
             value: "DESIRE_GRAPE"
       - name: "grapefruit"
         doc: "most people don't seem to like them"
-        wrapped:
+        source:
           c:
             value: "MANGIAMO_GRAPEFRUIT"
       - name: "lemon"
         doc: "not the variety that will burn your house down"
-        wrapped:
+        source:
           c:
             value: "MANGIAMO_LEMON"
       - name: "lime"
         doc: "good in blue moon and tequila!"
-        wrapped:
+        source:
           c:
             value: "MANGIAMO_LIME"
       - name: "orange"
         doc: "the fruit or the color? answer: yes"
-        wrapped:
+        source:
           c:
             value: "MANGIAMO_ORANGE"
       - name: "tangelo"
         doc: "sometimes called the Ugli fruit. ouch."
-        wrapped:
+        source:
           c:
             value: "MANGIAMO_TANGELO"
       - name: "watermelon"
         doc: "seedless? what will I spit at my sibling?"
-        wrapped:
+        source:
           c:
             value: "DESIRE_WATERMELON"

--- a/docs/examples/exceptions/turret.yml
+++ b/docs/examples/exceptions/turret.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020-2025 Joel E. Anderson
+# Copyright 2020-2026 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,19 +21,19 @@ classes:
   - name: "Turret"
     namespace: "defense_turret"
     libraries: "turret"
-    wrapped:
+    source:
       c:
         pointer:
           name: "turret"
           includes: "turret.h"
     constructors:
-      - wrapped:
+      - source:
           c:
             name: "new_turret"
             return:
               type: "equivalent_struct_pointer"
     destructor:
-      wrapped:
+      source:
         c:
           name: "destroy_turret"
           params:
@@ -47,7 +47,7 @@ classes:
             type: "int"
           - name: "z"
             type: "int"
-        wrapped:
+        source:
           c:
             name: "aim"
             params:
@@ -69,7 +69,7 @@ classes:
       - name: "AmmoCount"
         return:
           type: "int"
-        wrapped:
+        source:
           c:
             name: "ammo_count"
             params:
@@ -77,7 +77,7 @@ classes:
             return:
               type: "int"
       - name: "Fire"
-        wrapped:
+        source:
           c:
             name: "fire"
             params:
@@ -94,7 +94,7 @@ classes:
                 type: "TurretException"
                 value: "return_value"
       - name: "Reload"
-        wrapped:
+        source:
           c:
             name: "reload"
             params:
@@ -102,13 +102,13 @@ classes:
   - name: "TurretException"
     namespace: "defense_turret"
     exception: true
-    wrapped:
+    source:
       c:
         pointer:
           name: "turret_error"
           includes: "turret_error.h"
     constructors:
-      - wrapped:
+      - source:
           c:
             name: "null_error"
             return:
@@ -118,7 +118,7 @@ classes:
         virtual: true
         return:
           type: "const char *"
-        wrapped:
+        source:
           c:
             name: "get_error_message"
             includes: "turret_error.h"
@@ -132,7 +132,7 @@ classes:
     parent:
       name: "TurretException"
     exception: true
-    wrapped:
+    source:
       c:
         pointer:
           name: "turret_error"
@@ -145,7 +145,7 @@ classes:
       - name: "message"
         return:
           type: "const char *"
-        wrapped:
+        source:
           c:
             name: "get_error_message"
             includes: "turret_error.h"
@@ -159,7 +159,7 @@ classes:
     parent:
       name: "TurretException"
     exception: true
-    wrapped:
+    source:
       c:
         pointer:
           name: "turret_error"
@@ -172,7 +172,7 @@ classes:
       - name: "message"
         return:
           type: "const char *"
-        wrapped:
+        source:
           c:
             name: "get_error_message"
             includes: "turret_error.h"
@@ -186,7 +186,7 @@ classes:
     parent:
       name: "TurretException"
     exception: true
-    wrapped:
+    source:
       c:
         pointer:
           name: "turret_error"
@@ -199,7 +199,7 @@ classes:
       - name: "message"
         return:
           type: "const char *"
-        wrapped:
+        source:
           c:
             name: "get_error_message"
             includes: "turret_error.h"

--- a/docs/examples/inheritance/mylib.yml
+++ b/docs/examples/inheritance/mylib.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2025 Joel E. Anderson
+# Copyright 2025-2026 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ classes:
   - name: "Item"
     namespace: "library"
     libraries: "mylib"
-    wrapped:
+    source:
       c:
         name: "mylib_item"
         includes:
@@ -36,7 +36,7 @@ classes:
             default_value: "0"
     functions:
       - name: CheckOut
-        wrapped:
+        source:
           c:
             name: "check_out_item"
             params:
@@ -47,7 +47,7 @@ classes:
     libraries: "mylib"
     parent:
       name: "Item"
-    wrapped:
+    source:
       c:
         name: "mylib_item"
         includes:
@@ -67,7 +67,7 @@ classes:
       - name: GetPageCount
         return:
           type: "int"
-        wrapped:
+        source:
           c:
             name: "get_page_count"
             params:

--- a/docs/examples/nested_structs/fridge.yml
+++ b/docs/examples/nested_structs/fridge.yml
@@ -19,13 +19,13 @@ classes:
     namespace: "kitchen"
     libraries: "fridge"
     includes: "fridge.h"
-    wrapped:
+    source:
       c:
         pointer:
           name: "struct ice_maker"
           includes: "fridge.h"
     constructors:
-      - wrapped:
+      - source:
           c:
             name: "new_ice_maker"
             params:
@@ -39,13 +39,13 @@ classes:
     namespace: "kitchen"
     libraries: "fridge"
     includes: "fridge.h"
-    wrapped:
+    source:
       c:
         pointer:
           name: "struct water_filter"
           includes: "fridge.h"
     constructors:
-      - wrapped:
+      - source:
           c:
             name: "new_water_filter"
             params:
@@ -56,13 +56,13 @@ classes:
   - name: "Freezer"
     namespace: "kitchen"
     libraries: "fridge"
-    wrapped:
+    source:
       c:
         pointer:
           name: "struct freezer"
           includes: "fridge.h"
     constructors:
-      - wrapped:
+      - source:
           c:
             name: "new_freezer"
             params:
@@ -77,13 +77,13 @@ classes:
     libraries: "fridge"
     includes:
       - "fridge.h"
-    wrapped:
+    source:
       c:
         pointer:
           name: "fridge"
           includes: "fridge.h"
     constructors:
-      - wrapped:
+      - source:
           c:
             name: "new_fridge"
             params:
@@ -96,7 +96,7 @@ classes:
         params:
           - name: "new_ice_maker"
             type: "IceMaker"
-        wrapped:
+        source:
           c:
             name: "add_ice_maker_to_fridge"
             params:
@@ -107,7 +107,7 @@ classes:
         params:
           - name: "new_filter"
             type: "WaterFilter"
-        wrapped:
+        source:
           c:
             name: "add_water_filter_to_fridge"
             params:
@@ -118,7 +118,7 @@ classes:
         params:
           - name: "new_freezer"
             type: "Freezer"
-        wrapped:
+        source:
           c:
             name: "add_freezer_to_fridge"
             params:
@@ -128,7 +128,7 @@ classes:
       - name: "GetFreezerMinimumTemp"
         return:
           type: "int"
-        wrapped:
+        source:
           c:
             name: "get_freezer_minimum_temp"
             params:
@@ -136,7 +136,7 @@ classes:
             return:
               type: "int"
       - name: "Print"
-        wrapped:
+        source:
           c:
             name: "print_fridge"
             params:

--- a/docs/examples/overloaded_struct/security_system.yml
+++ b/docs/examples/overloaded_struct/security_system.yml
@@ -19,18 +19,18 @@ classes:
   - name: "SecurityEvent"
     namespace: "home_automation"
     libraries: "security_system"
-    wrapped:
+    source:
       c:
         pointer:
           name: "event"
           includes: "security_system.h"
     constructors:
-      - wrapped:
+      - source:
           c:
             name: "new_default_event"
             return:
               type: "equivalent_struct_pointer"
-      - wrapped:
+      - source:
           c:
             name: "new_event"
             params:
@@ -41,7 +41,7 @@ classes:
             return:
               type: "equivalent_struct_pointer"
     destructor:
-      wrapped:
+      source:
         c:
           name: "destroy_event"
           params:
@@ -51,7 +51,7 @@ classes:
         virtual: true
         return:
           type: "int"
-        wrapped:
+        source:
           c:
             name: "get_event_code"
             includes: "security_system.h"
@@ -64,7 +64,7 @@ classes:
         return:
           type: "SecurityEvent *"
           overloaded: true
-        wrapped:
+        source:
           c:
             name: "get_next_event"
             includes: "security_system.h"
@@ -72,7 +72,7 @@ classes:
               type: "equivalent_struct_pointer"
       - name: "Print"
         virtual: true
-        wrapped:
+        source:
           c:
             name: "print_event"
             includes: "security_system.h"
@@ -83,7 +83,7 @@ classes:
     libraries: "security_system"
     parent:
       name: "SecurityEvent"
-    wrapped:
+    source:
       c:
         pointer:
           name: "event"
@@ -93,7 +93,7 @@ classes:
               condition: "equal"
               value: "CAMERA_EVENT"
     constructors:
-      - wrapped:
+      - source:
           c:
             name: "new_camera_event"
             params:
@@ -105,14 +105,14 @@ classes:
       - name: "GetCode"
         return:
           type: "int"
-        wrapped:
+        source:
           c:
             name: "get_camera_event_code"
             includes: "security_system.h"
             return:
               type: "int"
       - name: "Print"
-        wrapped:
+        source:
           c:
             name: "print_camera_event"
             includes: "security_system.h"
@@ -123,7 +123,7 @@ classes:
     libraries: "security_system"
     parent:
       name: "SecurityEvent"
-    wrapped:
+    source:
       c:
         pointer:
           name: "event"
@@ -133,7 +133,7 @@ classes:
               condition: "equal"
               value: "GLASS_BREAK_EVENT"
     constructors:
-      - wrapped:
+      - source:
           c:
             name: "new_glass_break_event"
             params:
@@ -145,14 +145,14 @@ classes:
       - name: "GetCode"
         return:
           type: "int"
-        wrapped:
+        source:
           c:
             name: "get_glass_break_event_code"
             includes: "security_system.h"
             return:
               type: "int"
       - name: "Print"
-        wrapped:
+        source:
           c:
             name: "print_glass_break_event"
             includes: "security_system.h"
@@ -163,7 +163,7 @@ classes:
     libraries: "security_system"
     parent:
       name: "SecurityEvent"
-    wrapped:
+    source:
       c:
         pointer:
           name: "event"
@@ -173,7 +173,7 @@ classes:
               condition: "equal"
               value: "MOTION_EVENT"
     constructors:
-      - wrapped:
+      - source:
           c:
             name: "new_motion_event"
             params:
@@ -185,14 +185,14 @@ classes:
       - name: "GetCode"
         return:
           type: "int"
-        wrapped:
+        source:
           c:
             name: "get_motion_event_code"
             includes: "security_system.h"
             return:
               type: "int"
       - name: "Print"
-        wrapped:
+        source:
           c:
             name: "print_motion_event"
             includes: "security_system.h"

--- a/docs/examples/struct_wrapper/stats.yml
+++ b/docs/examples/struct_wrapper/stats.yml
@@ -18,7 +18,7 @@ classes:
   - name: "PlayerStats"
     namespace: "soccer"
     libraries: "stats"
-    wrapped:
+    source:
       c:
         name: "player_stats"
         includes: "stats.h"
@@ -39,7 +39,7 @@ classes:
       - name: "GetGoalsScored"
         return:
           type: "int"
-        wrapped:
+        source:
           c:
             name: "get_goals_scored"
             params:
@@ -49,7 +49,7 @@ classes:
       - name: "GetRedCards"
         return:
           type: "int"
-        wrapped:
+        source:
           c:
             name: "get_red_cards"
             params:
@@ -59,7 +59,7 @@ classes:
       - name: "GetYellowCards"
         return:
           type: "int"
-        wrapped:
+        source:
           c:
             name: "get_yellow_cards"
             params:
@@ -67,7 +67,7 @@ classes:
             return:
               type: "int"
       - name: "Print"
-        wrapped:
+        source:
           c:
             name: "print_player_stats"
             params:

--- a/lib/wrapture/action_spec.rb
+++ b/lib/wrapture/action_spec.rb
@@ -3,7 +3,7 @@
 # frozen_string_literal: true
 
 #--
-# Copyright 2020-2025 Joel E. Anderson
+# Copyright 2020-2026 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ module Wrapture
       normalized = spec.dup
 
       required_keys = %i[name type]
-      optional_keys = %i[value wrapped]
+      optional_keys = %i[value source]
 
       extra_keys = spec.keys - required_keys - optional_keys
       unless extra_keys.empty?
@@ -68,8 +68,8 @@ module Wrapture
 
     # A list of includes needed for the action.
     def includes
-      if @spec.key?(:wrapped) && @spec[:wrapped].key?(:c)
-        @spec[:wrapped][:c][:includes].dup
+      if @spec.key?(:source) && @spec[:source].key?(:c)
+        @spec[:source][:c][:includes].dup
       else
         []
       end

--- a/lib/wrapture/class_spec.rb
+++ b/lib/wrapture/class_spec.rb
@@ -38,19 +38,16 @@ module Wrapture
     # The scope of this class.
     attr_reader :scope
 
-    # The underlying struct of this class.
-    # attr_reader :struct
-
     # A map of language-specific wrapping details.
-    attr_accessor :wrapped
+    attr_accessor :source
 
     # Gives the effective type of the given class spec hash.
     # TODO: this should be refactored to use an object instead of a hash
     def self.effective_type(spec)
       inferred_pointer_wrapper = spec[:constructors].any? do |func|
         # TODO: this should not have c-specific code
-        func[:wrapped].key?(:c) &&
-          func[:wrapped][:c][:return][:type] == EQUIVALENT_POINTER_KEYWORD
+        func[:source].key?(:c) &&
+          func[:source][:c][:return][:type] == EQUIVALENT_POINTER_KEYWORD
       end
 
       if spec.key?(:type)
@@ -72,10 +69,10 @@ module Wrapture
     def self.from_hash(spec)
       if spec.key?(:constructors)
         c_constructors = spec[:constructors].reject do |it|
-          it.dig(:wrapped, :c).nil?
+          it.dig(:source, :c).nil?
         end
         if c_constructors.any? do |it|
-          it.dig(:wrapped, :c, :return, :type).nil?
+          it.dig(:source, :c, :return, :type).nil?
         end
           raise InvalidConstructor, 'a constructor did not have a return type'
         end
@@ -83,12 +80,12 @@ module Wrapture
 
       class_spec = new(spec)
 
-      if spec.key?(:wrapped) && spec[:wrapped].key?(:c)
-        if spec[:wrapped][:c].key?(:pointer)
-          struct_type = CSource::CStruct.from_hash(spec[:wrapped][:c][:pointer])
+      if spec.key?(:source) && spec[:source].key?(:c)
+        if spec[:source][:c].key?(:pointer)
+          struct_type = CSource::CStruct.from_hash(spec[:source][:c][:pointer])
           class_spec[:c] = CSource::CPointer.new(struct_type)
         else
-          class_spec[:c] = CSource::CStruct.from_hash(spec[:wrapped][:c])
+          class_spec[:c] = CSource::CStruct.from_hash(spec[:source][:c])
         end
       end
 
@@ -172,8 +169,8 @@ module Wrapture
         full_spec = constructor_spec.dup
         full_spec[:name] = @spec[:name]
         # TODO: there shouldn't be C-specific code here
-        if constructor_spec[:wrapped].key?(:c)
-          full_spec[:params] = constructor_spec[:wrapped][:c][:params]
+        if constructor_spec[:source].key?(:c)
+          full_spec[:params] = constructor_spec[:source][:c][:params]
         end
         full_spec[:constructor] = true
 
@@ -208,27 +205,27 @@ module Wrapture
       scope << self
       @scope = scope
 
-      @wrapped = {}
-      if @spec.key?(:wrapped) && @spec[:wrapped].key?(:c)
-        if @spec[:wrapped][:c].key?(:pointer)
-          struct_type = CSource::CStruct.from_hash(spec[:wrapped][:c][:pointer])
-          @wrapped[:c] = CSource::CPointer.new(struct_type)
+      @source = {}
+      if @spec.key?(:source) && @spec[:source].key?(:c)
+        if @spec[:source][:c].key?(:pointer)
+          struct_type = CSource::CStruct.from_hash(spec[:source][:c][:pointer])
+          @source[:c] = CSource::CPointer.new(struct_type)
         else
-          @wrapped[:c] = CSource::CStruct.from_hash(spec[:wrapped][:c])
+          @source[:c] = CSource::CStruct.from_hash(spec[:source][:c])
         end
       end
     end
 
     # Get the wrapping details for the given language. This is equivalent to
-    # +wrapped[lang]+.
+    # +source[lang]+.
     def [](lang)
-      @wrapped[lang]
+      @source[lang]
     end
 
     # Set the wrapping details for the given language. This is equivalent to
-    # +wrapped[lang]=+.
-    def []=(lang, wrapped_function)
-      @wrapped[lang] = wrapped_function
+    # +source[lang]=+.
+    def []=(lang, source_struct)
+      @source[lang] = source_struct
     end
 
     # True if the class has a parent.

--- a/lib/wrapture/enum_spec.rb
+++ b/lib/wrapture/enum_spec.rb
@@ -41,7 +41,7 @@ module Wrapture
     attr_reader :scope
 
     # A map of language-specific wrapping details.
-    attr_reader :wrapped
+    attr_reader :source
 
     # Creates a new EnumSpec from hash +spec+.
     # TODO: remove scope argument, this should not be tracked by the enum
@@ -69,24 +69,24 @@ module Wrapture
       enum.doc = Comment.new(spec[:doc])
       enum.namespace = spec[:namespace] if spec.key?(:namespace)
 
-      if spec.key?(:wrapped) && spec[:wrapped].key?(:c)
-        c_spec = spec[:wrapped][:c]
+      if spec.key?(:source) && spec[:source].key?(:c)
+        c_spec = spec[:source][:c]
         inc = Wrapture.normalize_array(c_spec.fetch(:includes, nil))
-        enum.wrapped[:c] = { includes: inc }
+        enum[:c] = { includes: inc }
       end
 
       spec[:elements].each do |it|
         element = { name: Wrapture.normalize_name(it, :name) }
         element[:doc] = Comment.new(it[:doc]) if it.key?(:doc)
-        if it.key?(:wrapped) && it[:wrapped].key?(:c)
-          element[:wrapped] = { c: {} }
+        if it.key?(:source) && it[:source].key?(:c)
+          element[:source] = { c: {} }
 
-          if it[:wrapped][:c].key?(:value)
-            element[:wrapped][:c][:value] = it[:wrapped][:c][:value]
+          if it[:source][:c].key?(:value)
+            element[:source][:c][:value] = it[:source][:c][:value]
           end
 
-          inc = Wrapture.normalize_array(it[:wrapped][:c].fetch(:includes, nil))
-          element[:wrapped][:c][:includes] = inc
+          inc = Wrapture.normalize_array(it[:source][:c].fetch(:includes, nil))
+          element[:source][:c][:includes] = inc
         end
 
         enum.elements << element
@@ -168,7 +168,19 @@ module Wrapture
       # TODO: this should be an array of custom objects instead of hashes
       @elements = []
 
-      @wrapped = {}
+      @source = {}
+    end
+
+    # Get the source details for the given language. This is equivalent to
+    # +source[lang]+.
+    def [](lang)
+      @source[lang]
+    end
+
+    # Set the source details for the given language. This is equivalent to
+    # +source[lang]=+.
+    def []=(lang, source_details)
+      @source[lang] = source_details
     end
 
     # An array of libraries needed for everything in this enum.

--- a/lib/wrapture/function_spec.rb
+++ b/lib/wrapture/function_spec.rb
@@ -57,14 +57,14 @@ module Wrapture
     # A TypeSpec describing the return type of this function.
     attr_accessor :return_type
 
+    # A map of source language functions this spec wraps.
+    attr_accessor :source
+
     # Set whether this function is static.
     attr_writer :static
 
     # Set whether this function is virtual.
     attr_writer :virtual
-
-    # A map of language-specific functions this spec wraps.
-    attr_accessor :wrapped
 
     # Creates a new FunctionSpec from hash +spec+.
     #
@@ -75,7 +75,7 @@ module Wrapture
     # in this array must be a +Hash+ used to create a +ParamSpec+. Only one
     # parameter may be named +...+ and it must be last in the +Array+.
     #
-    # The +:wrapped+ key contains a +Hash+ that describes the implementation
+    # The +:source+ key contains a +Hash+ that describes the implementation
     # of the function. This may either contain a +:c+ key containing a +Hash+
     # used to create a +CFunction+, or an +:alias+ key with the name of another
     # function (either a +String+ or an +Array+ of words) that this one is
@@ -150,14 +150,14 @@ module Wrapture
         end
       end
 
-      wrapped_from_hash(func_spec, spec[:wrapped]) if spec.key?(:wrapped)
+      set_source_from_hash(func_spec, spec[:source]) if spec.key?(:source)
 
       func_spec
     end
 
-    # Sets the members of the +wrapped+ property of the +FunctionSpec+ +spec+
+    # Sets the members of the +source+ property of the +FunctionSpec+ +spec+
     # based on the contents of +hash+.
-    private_class_method def self.wrapped_from_hash(spec, hash)
+    private_class_method def self.set_source_from_hash(spec, hash)
       if hash.key?(:alias)
         spec[:alias] = hash[:alias]
       elsif hash.key?(:c)
@@ -172,7 +172,7 @@ module Wrapture
       @name_words = Wrapture.normalize_name_words(name)
       @doc = nil
       @owner = Scope.new
-      @wrapped = {}
+      @source = {}
       @params = []
       @return_doc = nil
       @return_overloaded = false
@@ -184,16 +184,16 @@ module Wrapture
       @initializers = []
     end
 
-    # Get the wrapped function for the given language. This is equivalent to
-    # +wrapped[lang]+.
+    # Get the source function for the given language. This is equivalent to
+    # +source[lang]+.
     def [](lang)
-      @wrapped[lang]
+      @source[lang]
     end
 
-    # Set the wrapped function for the given language. This is equivalent to
-    # +wrapped[lang]=+.
-    def []=(lang, wrapped_function)
-      @wrapped[lang] = wrapped_function
+    # Set the source function for the given language. This is equivalent to
+    # +source[lang]=+.
+    def []=(lang, source_function)
+      @source[lang] = source_function
     end
 
     # True if the function is a constructor, false otherwise.
@@ -219,15 +219,15 @@ module Wrapture
     # "wrappable?" and added to ClassSpec and/or Scope.
     def definable?(lang: nil)
       if lang.nil?
-        !@wrapped.empty?
+        !@source.empty?
       else
-        @wrapped.key?(lang)
+        @source.key?(lang)
       end
     end
 
     # A list of includes needed for the definition of the function.
     def definition_includes
-      includes = @wrapped[:c].includes
+      includes = @source[:c].includes
       includes.concat(@return_type.includes)
       @params.each { |param| includes.concat(param.includes) }
       includes.concat(@return_type.includes)
@@ -257,10 +257,10 @@ module Wrapture
     # An array of libraries required for this function call.
     def libraries
       # TODO: there shouldn't be C-specific code here
-      if @wrapped.empty? || !@wrapped.key?(:c)
+      if @source.empty? || !@source.key?(:c)
         []
       else
-        @wrapped[:c].libraries
+        @source[:c].libraries
       end
     end
 

--- a/lib/wrapture/wrapper/c.rb
+++ b/lib/wrapture/wrapper/c.rb
@@ -40,7 +40,7 @@ module Wrapture
 
         parent = class_spec.parent_spec
         !parent.nil? &&
-          parent.wrapped.key?(:c) &&
+          parent.source.key?(:c) &&
           parent[:c] == class_spec[:c]
       end
 
@@ -51,7 +51,7 @@ module Wrapture
       # ancestor's members if it wraps the same struct.
       def self.equivalent_member?(class_spec)
         # there's no equivalent member if there's no wrapped struct
-        return false unless class_spec.wrapped.key?(:c)
+        return false unless class_spec.source.key?(:c)
 
         # let's see if we can re-use an ancestor's struct
         !equivalent_ancestor?(class_spec)
@@ -61,7 +61,7 @@ module Wrapture
       # struct exists, nil if not. If the class wraps a struct directly, this
       # type will be a pointer to the struct type, not the struct type itself.
       def self.equivalent_pointer(class_spec)
-        if class_spec.wrapped.key?(:c)
+        if class_spec.source.key?(:c)
           if class_spec[:c].instance_of?(CSource::CStruct)
             CSource::CPointer.new(class_spec[:c])
           else
@@ -74,7 +74,7 @@ module Wrapture
       # If the class wraps a pointer to a struct, this type will be the struct
       # type, not the pointer type.
       def self.equivalent_struct(class_spec)
-        if class_spec.wrapped.key?(:c)
+        if class_spec.source.key?(:c)
           if class_spec[:c].instance_of?(CSource::CPointer)
             class_spec[:c].c_type
           else
@@ -86,7 +86,7 @@ module Wrapture
       # The type of the equivalent struct for a class spec if one exists, nil
       # if not.
       def self.equivalent_type(class_spec)
-        class_spec[:c] if class_spec.wrapped.key?(:c)
+        class_spec[:c] if class_spec.source.key?(:c)
       end
 
       # True if the given ClassSpec is a factory in the given context. A factory
@@ -123,7 +123,7 @@ module Wrapture
               when Scope
                 spec.flat_map { |it| includes(it) }
               when ClassSpec
-                spec_includes = if spec.wrapped.key?(:c)
+                spec_includes = if spec.source.key?(:c)
                                   spec[:c].includes
                                 else
                                   []
@@ -136,7 +136,7 @@ module Wrapture
                 end
                 spec_includes + constant_includes + function_includes
               when FunctionSpec
-                spec_includes = if spec.wrapped.key?(:c)
+                spec_includes = if spec.source.key?(:c)
                                   spec[:c].includes
                                 else
                                   []
@@ -148,12 +148,10 @@ module Wrapture
               when EnumSpec
                 spec_includes = []
 
-                if spec.wrapped.key?(:c)
-                  spec_includes += spec.wrapped[:c][:includes]
-                end
+                spec_includes += spec[:c][:includes] if spec.source.key?(:c)
 
                 spec.elements.each do |it|
-                  it_inc = it.dig(:wrapped, :c, :includes)
+                  it_inc = it.dig(:source, :c, :includes)
                   spec_includes += it_inc unless it_inc.nil?
                 end
 
@@ -187,7 +185,7 @@ module Wrapture
       # defined in it. This is useful for determing if a constructor or
       # accessors can be generated based on the fields.
       def self.wrapped_members?(class_spec)
-        class_spec.wrapped.key?(:c) &&
+        class_spec.source.key?(:c) &&
           class_spec[:c].is_a?(CSource::CStruct) &&
           !class_spec[:c].members.empty?
       end

--- a/lib/wrapture/wrapper/c_to_cpp.rb
+++ b/lib/wrapture/wrapper/c_to_cpp.rb
@@ -152,7 +152,7 @@ module Wrapture
       def self.declaration_includes(class_spec, scope)
         includes = ["#{CSource::CExportHeader.export_header_name(scope)}pp"]
 
-        includes.concat(class_spec[:c].includes) if class_spec.wrapped.key?(:c)
+        includes.concat(class_spec[:c].includes) if class_spec.source.key?(:c)
 
         class_spec.functions.each do |func|
           func.params.each do |param|
@@ -213,7 +213,7 @@ module Wrapture
         blk << 'va_list variadic_args;' if func_spec.variadic?
 
         if wrapper_captures_return?(func_spec)
-          return_type = func_spec.wrapped[:c].return_type
+          return_type = func_spec[:c].return_type
           if return_type.to_s == EQUIVALENT_STRUCT_KEYWORD
             return_type = C.equivalent_struct(func_spec.owner)
           end
@@ -258,7 +258,7 @@ module Wrapture
 
       # Generate the definition for a constructor function.
       def self.define_constructor(class_spec, func_spec)
-        if func_spec.wrapped.key?(:alias)
+        if func_spec.source.key?(:alias)
           return define_alias_constructor(class_spec, func_spec)
         end
 
@@ -440,7 +440,7 @@ module Wrapture
         end
 
         class_spec.functions.each do |func_spec|
-          next unless func_spec.wrapped.key?(:c)
+          next unless func_spec.source.key?(:c)
 
           action = func_spec[:c].error_action
           next if action.nil?
@@ -463,7 +463,7 @@ module Wrapture
           element = { name: element_name }
 
           element[:doc] = it[:doc] if it.key?(:doc)
-          val = it.dig(:wrapped, :c, :value)
+          val = it.dig(:source, :c, :value)
           element[:value] = val unless val.nil?
 
           enum.elements << element
@@ -907,7 +907,7 @@ module Wrapture
 
       # The expression containing the call to the underlying wrapped function.
       def self.wrapped_function_call(func_spec)
-        wrapped = func_spec.wrapped[:c]
+        wrapped = func_spec[:c]
         params = wrapped.params.map do |it|
           resolve_wrapped_param(func_spec, it)
         end

--- a/lib/wrapture/wrapper/c_to_python.rb
+++ b/lib/wrapture/wrapper/c_to_python.rb
@@ -601,7 +601,7 @@ module Wrapture
           element_name = Named.snake_case_name(it[:name])
           f.puts("element_name = PyUnicode_FromString( \"#{element_name}\" );")
 
-          val = it.dig(:wrapped, :c, :value)
+          val = it.dig(:source, :c, :value)
           val = next_val if val.nil?
           f.puts("element_value = PyLong_FromLong( #{val} );")
 
@@ -1327,9 +1327,9 @@ module Wrapture
         CSource::CDeclaration.new(pointer_type, 'self')
       end
 
-      # The type of the wrapped source function.
+      # The type of the source function.
       def self.source_return_type(func_spec)
-        return_type = func_spec.wrapped[:c].return_type
+        return_type = func_spec[:c].return_type
 
         if return_type.to_s == EQUIVALENT_STRUCT_KEYWORD
           C.equivalent_struct(func_spec.owner)

--- a/sig/action_spec.rbs
+++ b/sig/action_spec.rbs
@@ -1,3 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2026 Joel E. Anderson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Wrapture
   class ActionSpec
     def self.normalize_spec_hash: (spec_hash spec) -> spec_hash

--- a/sig/class_spec.rbs
+++ b/sig/class_spec.rbs
@@ -18,22 +18,27 @@ module Wrapture
   class ClassSpec
     include Named
 
-    @spec: spec_hash
     @constants: Array[Wrapture::ConstantSpec]
-    @functions: Array[Wrapture::FunctionSpec]
     @doc: Wrapture::Comment
+    @functions: Array[Wrapture::FunctionSpec]
     @scope: Wrapture::Scope
+    @source: Hash[Symbol, CSource::CStruct]
+    @spec: spec_hash
+
+    attr_reader constants: Array[Wrapture::ConstantSpec]
+    attr_reader doc: Wrapture::Comment
+    attr_reader functions: Array[Wrapture::FunctionSpec]
+    attr_reader scope: Wrapture::Scope
+    attr_accessor source: Hash[Symbol, CSource::CStruct] | nil
 
     def self.effective_type: (spec_hash spec) -> String
     def self.from_hash: (spec_hash spec) -> Wrapture::ClassSpec
     def self.normalize_spec_hash: (spec_hash spec) -> spec_hash
     def self.normalize_spec_hash!: (spec_hash spec) -> spec_hash
-    attr_reader constants: Array[Wrapture::ConstantSpec]
-    attr_reader doc: Wrapture::Comment
-    attr_reader functions: Array[Wrapture::FunctionSpec]
-    attr_reader scope: Wrapture::Scope
-    attr_accessor wrapped: Hash[Symbol, untyped] | nil
+
     def initialize: (spec_hash spec, ?scope: Wrapture::Scope) -> void
+    def []: (Symbol) -> CSource::CStruct
+    def []=: (Symbol, CSource::CStruct) -> CSource::CStruct
     def child?: -> bool
     def constructors: -> Array[Wrapture::FunctionSpec]
     def definable?: () -> bool

--- a/sig/enum_spec.rbs
+++ b/sig/enum_spec.rbs
@@ -23,18 +23,22 @@ module Wrapture
     @name_words: Array[String]
     @namespace: String?
     @scope: Wrapture::Scope
-    @wrapped: Hash[Symbol, untyped] | nil
+    @source: Hash[Symbol, untyped] | nil
 
-    def self.from_hash: (spec_hash spec, ?scope: Wrapture::Scope) -> Wrapture::EnumSpec
-    def self.normalize_spec_hash: (spec_hash spec) -> spec_hash
-    def self.normalize_spec_hash!: (spec_hash spec) -> spec_hash
     attr_accessor doc: Wrapture::Comment
     attr_reader elements: Array[Hash[Symbol, untyped]]
     attr_reader name_words: Array[String]
     attr_accessor namespace: String?
     attr_accessor scope: Wrapture::Scope
-    attr_reader wrapped: Hash[Symbol, untyped] | nil
+    attr_reader source: Hash[Symbol, untyped] | nil
+
+    def self.from_hash: (spec_hash spec, ?scope: Wrapture::Scope) -> Wrapture::EnumSpec
+    def self.normalize_spec_hash: (spec_hash spec) -> spec_hash
+    def self.normalize_spec_hash!: (spec_hash spec) -> spec_hash
+
     def initialize: (spec_hash spec, ?scope: Wrapture::Scope) -> void
+    def []: (Symbol) -> untyped
+    def []=: (Symbol, untyped) -> untyped
     def libraries: -> Array[String]
     def namespace?: -> bool
   end

--- a/sig/function_spec.rbs
+++ b/sig/function_spec.rbs
@@ -1,24 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2026 Joel E. Anderson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Wrapture
   class FunctionSpec
     include Named
 
-    @owner: Wrapture::ClassSpec | Wrapture::Scope
-    @spec: spec_hash
-    @wrapped: Hash[Symbol, untyped] | nil
-    @params: Array[Wrapture::ParamSpec]
     @constructor: bool
     @destructor: bool
+    @owner: Wrapture::ClassSpec | Wrapture::Scope
+    @params: Array[Wrapture::ParamSpec]
+    @spec: spec_hash
+    @source: Hash[Symbol, CSource::CFunction] | nil
 
     attr_reader owner: Wrapture::ClassSpec | Wrapture::Scope
     attr_reader params: Array[Wrapture::ParamSpec]
     attr_reader return_type: Wrapture::TypeSpec
-    attr_accessor wrapped: Hash[Symbol, untyped] | nil
+    attr_accessor source: Hash[Symbol, CSource::CFunction] | nil
+    attr_writer static: bool
+    attr_writer virtual: bool
 
     def self.from_hash: (spec_hash spec) -> Wrapture::FunctionSpec
 
-    private def self.wrapped_from_hash: (Hash[Symbol, untyped]) -> void
+    private def self.set_source_from_hash: (FunctionSpec, Hash[Symbol, untyped]) -> void
 
     def initialize: (spec_hash spec, ?(Wrapture::ClassSpec | Wrapture::Scope) owner, ?constructor: bool, ?destructor: bool) -> void
+    def []: (Symbol) -> CSource::CFunction
+    def []=: (Symbol, CSource::CFunction) -> CSource::CFunction
     def constructor?: -> bool
     def declaration_includes: -> Array[String]
     def definable?: (?lang: Symbol) -> bool

--- a/test/fixtures/alias_constructor.yml
+++ b/test/fixtures/alias_constructor.yml
@@ -17,17 +17,17 @@
 name: "AliasConstructorClass"
 namespace: "wrapture_test"
 includes: "class_include.h"
-wrapped:
+source:
   c:
     pointer:
       name: "basic_struct"
       includes: "folder/include_file_1.h"
 constructors:
-  - wrapped:
+  - source:
       alias:
         args:
           - 3
-  - wrapped:
+  - source:
       c:
         name: "underlying_constructor"
         params:

--- a/test/fixtures/basic_action.yml
+++ b/test/fixtures/basic_action.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2025 Joel E. Anderson
+# Copyright 2025-2026 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 name: "throw_exception"
 type: "NewCustomException"
-wrapped:
+source:
   c:
     name: "stop_drop_and_freak_out"
     includes:

--- a/test/fixtures/basic_class.yml
+++ b/test/fixtures/basic_class.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2025 Joel E. Anderson
+# Copyright 2025-2026 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 name: "BasicClass"
 namespace: "wrapture_test"
 includes: "class_include.h"
-wrapped:
+source:
   c:
     pointer:
       name: "basic_struct"
@@ -27,7 +27,7 @@ functions:
     params:
       - name: "app_name"
         type: "const char *"
-    wrapped:
+    source:
       c:
         name: "underlying_basic_function"
         includes:

--- a/test/fixtures/basic_enum.yml
+++ b/test/fixtures/basic_enum.yml
@@ -15,19 +15,19 @@
 # limitations under the License.
 
 name: "BasicEnum"
-wrapped:
+source:
   c:
     includes:
       - "overall_1.h"
       - "overall_2.h"
 elements:
   - name: "element_1"
-    wrapped:
+    source:
       c:
         value: 9
         includes: "val_1.h"
   - name: "element_2"
-    wrapped:
+    source:
       c:
         value: 3
   - name: "element_3"

--- a/test/fixtures/basic_function.yml
+++ b/test/fixtures/basic_function.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2025 Joel E. Anderson
+# Copyright 2025-2026 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ name: "BasicFunction1"
 params:
   - name: "app_name"
     type: "const char *"
-wrapped:
+source:
   c:
     name: "underlying_basic_function"
     includes:

--- a/test/fixtures/child_class.yml
+++ b/test/fixtures/child_class.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2025 Joel E. Anderson
+# Copyright 2025-2026 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 name: "ChildClass"
 namespace: "wrapture_test"
-wrapped:
+source:
   c:
     pointer:
       name: "error_struct"

--- a/test/fixtures/class_with_return_val_in_constructor.yml
+++ b/test/fixtures/class_with_return_val_in_constructor.yml
@@ -16,12 +16,12 @@
 
 name: "ClassWithReturnActionInConstructor"
 namespace: "wrapture_test"
-wrapped:
+source:
   c:
     pointer:
       name: "irrelevant"
 constructors:
-  - wrapped:
+  - source:
       c:
         name: "wrapped_constructor"
         params:
@@ -39,7 +39,7 @@ constructors:
             type: "throwMyException"
             value: "name"
 destructor:
-  wrapped:
+  source:
     c:
       name: "wrapped_destructor"
       params:

--- a/test/fixtures/class_with_virtual_function.yml
+++ b/test/fixtures/class_with_virtual_function.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2025 Joel E. Anderson
+# Copyright 2025-2026 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,14 +16,14 @@
 
 name: "BaseClass"
 namespace: "wrapture_test"
-wrapped:
+source:
   c:
     name: "overloaded_struct"
     includes: "allthethings.h"
 functions:
   - name: "VirtualFunction"
     virtual: true
-    wrapped:
+    source:
       c:
         name: "vanilla_flavor"
         params:

--- a/test/fixtures/cmake_c_library/spec.yml
+++ b/test/fixtures/cmake_c_library/spec.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2025 Joel E. Anderson
+# Copyright 2025-2026 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ classes:
             type: "int"
         return:
           type: "int"
-        wrapped:
+        source:
           c:
             name: cmakeclib_add
             includes: "cmakeclib.h"

--- a/test/fixtures/constant_class.yml
+++ b/test/fixtures/constant_class.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2025 Joel E. Anderson
+# Copyright 2025-2026 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 name: "ClassWithConstant"
 namespace: "wrapture_test"
-wrapped:
+source:
   c:
     pointer:
       name: "basic_struct"

--- a/test/fixtures/constructor_class.yml
+++ b/test/fixtures/constructor_class.yml
@@ -16,7 +16,7 @@
 
 name: "ClassWithConstructor"
 namespace: "wrapture_test"
-wrapped:
+source:
   c:
     name: "constructed_struct"
     members:
@@ -25,7 +25,7 @@ wrapped:
     includes:
       - "constructed.h"
 constructors:
-  - wrapped:
+  - source:
       c:
         name: "build_a_struct"
         params:
@@ -34,7 +34,7 @@ constructors:
         return:
           type: "equivalent_struct"
         includes: "constructed.h"
-  - wrapped:
+  - source:
       c:
         name: "copy_struct"
         params:
@@ -44,7 +44,7 @@ constructors:
           type: "equivalent_struct"
         includes:
           - "constructed.h"
-  - wrapped:
+  - source:
       c:
         name: "copy_struct_pointer"
         params:
@@ -53,7 +53,7 @@ constructors:
         return:
           type: "equivalent_struct"
 destructor:
-  wrapped:
+  source:
     c:
       name: "destroy_a_struct"
       params:
@@ -67,7 +67,7 @@ functions:
         type: "equivalent_struct"
     return:
       type: "int"
-    wrapped:
+    source:
       c:
         name: "compare_structs"
         params:

--- a/test/fixtures/default_value_members.yml
+++ b/test/fixtures/default_value_members.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2025 Joel E. Anderson
+# Copyright 2025-2026 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 name: "DefaultMembersClass"
 namespace: "wrapture_test"
-wrapped:
+source:
   c:
     name: "struct_to_wrap"
     includes:
@@ -43,7 +43,7 @@ functions:
       type:
         name: "DefaultMembersClass"
         includes: "DefaultMembersClass.hpp"
-    wrapped:
+    source:
       c:
         name: "native_function"
         params:

--- a/test/fixtures/documented_function.yml
+++ b/test/fixtures/documented_function.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2025 Joel E. Anderson
+# Copyright 2025-2026 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ params:
     doc: "the name of an application. ParamDocIdentifier"
 return:
   doc: "returns a value. ReturnDocIdentifier"
-wrapped:
+source:
   c:
     name: "underlying_basic_function"
     includes:

--- a/test/fixtures/documented_params.yml
+++ b/test/fixtures/documented_params.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2025 Joel E. Anderson
+# Copyright 2025-2026 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ params:
   - name: "app_name"
     type: "const char *"
     doc: "the name of an application. ParamDocIdentifier"
-wrapped:
+source:
   c:
     name: "underlying_basic_function"
     includes:

--- a/test/fixtures/enum_with_namespace.yml
+++ b/test/fixtures/enum_with_namespace.yml
@@ -16,19 +16,19 @@
 
 name: "EnumWithNamespace"
 namespace: "wrapture_test"
-wrapped:
+source:
   c:
     includes:
       - "overall_1.h"
       - "overall_2.h"
 elements:
   - name: "element_1"
-    wrapped:
+    source:
       c:
         value: 9
     includes: "val_1.h"
   - name: "element_2"
-    wrapped:
+    source:
       c:
         value: 3
   - name: "element_3"

--- a/test/fixtures/exception_check_without_return_val.yml
+++ b/test/fixtures/exception_check_without_return_val.yml
@@ -17,7 +17,7 @@
 name: "ErrorCheckWithoutReturnVal"
 return:
   type: "int"
-wrapped:
+source:
   c:
     name: "underlying_function"
     error_check:

--- a/test/fixtures/exception_throwing_function.yml
+++ b/test/fixtures/exception_throwing_function.yml
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 name: "IMightFail"
-wrapped:
+source:
   c:
     name: "might_fail"
     return:

--- a/test/fixtures/explicit_pointer_class.yml
+++ b/test/fixtures/explicit_pointer_class.yml
@@ -16,7 +16,7 @@
 
 name: "ExplicitPointerWrapper"
 namespace: "wrapture_test"
-wrapped:
+source:
   c:
     pointer:
       name: "basic_struct"

--- a/test/fixtures/function_pointer_argument.yml
+++ b/test/fixtures/function_pointer_argument.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2025 Joel E. Anderson
+# Copyright 2025-2026 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ params:
           - type: "void *"
         return:
           type: "const char *"
-wrapped:
+source:
   c:
     name: "underlying_function"
     params:

--- a/test/fixtures/function_pointer_return.yml
+++ b/test/fixtures/function_pointer_return.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2025 Joel E. Anderson
+# Copyright 2025-2026 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ return:
             includes: "special_inc_1.h"
       return:
         type: "const char *"
-wrapped:
+source:
   c:
     name: "underlying_function"
     params:

--- a/test/fixtures/function_with_implicit_void_return.yml
+++ b/test/fixtures/function_with_implicit_void_return.yml
@@ -19,7 +19,7 @@ return:
   doc: |
     This function doesn't return anything, but there's still something you
     should know about what happens when it returns...
-wrapped:
+source:
   c:
     name: "underlying_function"
 

--- a/test/fixtures/function_with_initializers.yml
+++ b/test/fixtures/function_with_initializers.yml
@@ -25,7 +25,7 @@ initializers:
     value: "param_1"
   - name: "init_param_2"
     value: "param_2"
-wrapped:
+source:
   c:
     name: "underlying_function"
     params:

--- a/test/fixtures/invalid/class_with_c_constructor_return_type_mismatch.yml
+++ b/test/fixtures/invalid/class_with_c_constructor_return_type_mismatch.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2025 Joel E. Anderson
+# Copyright 2025-2026 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,11 +16,11 @@
 
 name: CConstructorReturnTypeMismatch
 namespace: invalid
-wrapped:
+source:
   c:
     name: my_struct
 constructors:
-  - wrapped:
+  - source:
       c:
         name: pointer_constructor
         return:

--- a/test/fixtures/invalid/class_with_invalid_doc.yml
+++ b/test/fixtures/invalid/class_with_invalid_doc.yml
@@ -17,6 +17,6 @@
 name: "MinimalClass"
 namespace: "wrapture_test"
 doc: 3
-wrapped:
+source:
   c:
     name: "minimal_struct"

--- a/test/fixtures/invalid/class_with_no_return_type_in_c_constructor.yml
+++ b/test/fixtures/invalid/class_with_no_return_type_in_c_constructor.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2025 Joel E. Anderson
+# Copyright 2025-2026 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,10 +16,10 @@
 
 name: CConstructorReturnTypeMismatch
 namespace: invalid
-wrapped:
+source:
   c:
     name: my_struct
 constructors:
-  - wrapped:
+  - source:
       c:
         name: pointer_constructor

--- a/test/fixtures/invalid/initializer_missing_name.yml
+++ b/test/fixtures/invalid/initializer_missing_name.yml
@@ -17,13 +17,13 @@
 name: "DelegatingConstructorClass"
 namespace: "wrapture_test"
 includes: "class_include.h"
-wrapped:
+source:
   c:
     pointer:
       name: "basic_struct"
       includes: "folder/include_file_1.h"
 constructors:
-  - wrapped:
+  - source:
       c:
         name: "default_constructor"
         return:
@@ -31,7 +31,7 @@ constructors:
     initializers:
       - values:
           - 3
-  - wrapped:
+  - source:
       c:
         name: "underlying_constructor"
         params:

--- a/test/fixtures/invalid/invalid_virtual_key.yml
+++ b/test/fixtures/invalid/invalid_virtual_key.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2025 Joel E. Anderson
+# Copyright 2025-2026 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 name: "VirtualFunction"
 virtual: "yes, please"
-wrapped:
+source:
   c:
     name: "underlying_function"
     params:

--- a/test/fixtures/invalid/no_namespace.yml
+++ b/test/fixtures/invalid/no_namespace.yml
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 name: "NoNamespace"
-wrapped:
+source:
   c:
     name: "struct_name"
     includes: "struct_file.h"

--- a/test/fixtures/invalid/only_variadic_param.yml
+++ b/test/fixtures/invalid/only_variadic_param.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2025 Joel E. Anderson
+# Copyright 2025-2026 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 name: "InvalidVariadicFunction"
 params:
   - name: "..."
-wrapped:
+source:
   c:
     name: "underlying_function"
     params:

--- a/test/fixtures/invalid/rule_missing_condition.yml
+++ b/test/fixtures/invalid/rule_missing_condition.yml
@@ -18,7 +18,7 @@ version: "0.6.0"
 classes:
   - name: "Parent"
     namespace: "wrapture_test"
-    wrapped:
+    source:
       c:
         name: "overloaded_struct"
         members:
@@ -26,7 +26,7 @@ classes:
             type: "int"
   - name: "ChildOne"
     namespace: "wrapture_test"
-    wrapped:
+    source:
       c:
         name: "overloaded_struct"
         rules:

--- a/test/fixtures/invalid/rule_with_invalid_condition.yml
+++ b/test/fixtures/invalid/rule_with_invalid_condition.yml
@@ -18,7 +18,7 @@ version: "0.6.0"
 classes:
   - name: "Parent"
     namespace: "wrapture_test"
-    wrapped:
+    source:
       c:
         name: "overloaded_struct"
         members:
@@ -26,7 +26,7 @@ classes:
             type: "int"
   - name: "ChildOne"
     namespace: "wrapture_test"
-    wrapped:
+    source:
       c:
         name: "overloaded_struct"
         rules:

--- a/test/fixtures/invalid/rule_with_invalid_key.yml
+++ b/test/fixtures/invalid/rule_with_invalid_key.yml
@@ -18,7 +18,7 @@ version: "0.6.0"
 classes:
   - name: "Parent"
     namespace: "wrapture_test"
-    wrapped:
+    source:
       c:
         name: "overloaded_struct"
         members:
@@ -26,7 +26,7 @@ classes:
             type: "int"
   - name: "ChildOne"
     namespace: "wrapture_test"
-    wrapped:
+    source:
       c:
         name: "overloaded_struct"
         rules:

--- a/test/fixtures/nested_structs.yml
+++ b/test/fixtures/nested_structs.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2025 Joel E. Anderson
+# Copyright 2025-2026 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 classes:
   - name: "Gym"
     namespace: "wrapture_test"
-    wrapped:
+    source:
       c:
         name: "gym"
     functions:
@@ -27,7 +27,7 @@ classes:
             type:
               name: "Pool"
               includes: "Pool.hpp"
-        wrapped:
+        source:
           c:
             name: "add_pool_to_gym"
             params:
@@ -43,7 +43,7 @@ classes:
             type:
               name: "Pool"
               includes: "Pool.hpp"
-        wrapped:
+        source:
           c:
             name: "copy_pool_to_gym"
             params:
@@ -59,7 +59,7 @@ classes:
             type:
               name: "Track"
               includes: "Track.hpp"
-        wrapped:
+        source:
           c:
             name: "add_track_to_gym"
             params:
@@ -75,7 +75,7 @@ classes:
             type:
               name: "Track"
               includes: "Track.hpp"
-        wrapped:
+        source:
           c:
             name: "copy_track_to_gym"
             params:
@@ -87,12 +87,12 @@ classes:
                   includes: "gym.h"
   - name: "Pool"
     namespace: "wrapture_test"
-    wrapped:
+    source:
       c:
         pointer:
           name: "gym_pool"
     constructors:
-      - wrapped:
+      - source:
             c:
               name: "new_pool"
               params:
@@ -102,12 +102,12 @@ classes:
                 type: "equivalent_struct_pointer"
   - name: "Track"
     namespace: "wrapture_test"
-    wrapped:
+    source:
       c:
         pointer:
           name: "gym_track"
     constructors:
-      - wrapped:
+      - source:
           c:
             name: "new_track"
             params:

--- a/test/fixtures/no_cast_function.yml
+++ b/test/fixtures/no_cast_function.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2025 Joel E. Anderson
+# Copyright 2025-2026 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 name: "BasicFunction1"
 return:
   type: "const char *"
-wrapped:
+source:
   c:
     name: "underlying_basic_function"
     return:

--- a/test/fixtures/no_struct_class.yml
+++ b/test/fixtures/no_struct_class.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2025 Joel E. Anderson
+# Copyright 2025-2026 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,6 +19,6 @@ namespace: "wrapture_test"
 functions:
   - name: "StaticFunction"
     static: true
-    wrapped:
+    source:
       c:
         name: "underlying_function"

--- a/test/fixtures/overloaded_struct.yml
+++ b/test/fixtures/overloaded_struct.yml
@@ -18,7 +18,7 @@ version: "0.6.0"
 classes:
   - name: "Parent"
     namespace: "wrapture_test"
-    wrapped:
+    source:
       c:
         name: "overloaded_struct"
         members:
@@ -29,7 +29,7 @@ classes:
         return:
           type: "Parent *"
           overloaded: true
-        wrapped:
+        source:
           c:
             name: "overloaded_type"
             return:
@@ -38,7 +38,7 @@ classes:
     namespace: "wrapture_test"
     parent:
       name: "Parent"
-    wrapped:
+    source:
       c:
         name: "overloaded_struct"
         rules:
@@ -49,7 +49,7 @@ classes:
     namespace: "wrapture_test"
     parent:
       name: "Parent"
-    wrapped:
+    source:
       c:
         name: "overloaded_struct"
         rules:

--- a/test/fixtures/pointer_class.yml
+++ b/test/fixtures/pointer_class.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2025 Joel E. Anderson
+# Copyright 2025-2026 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,13 +16,13 @@
 
 name: "PointerWrappingClass"
 namespace: "wrapture_test"
-wrapped:
+source:
   c:
     pointer:
       name: "wrapped_struct"
       includes: "wrapme.h"
 constructors:
-  - wrapped:
+  - source:
       c:
         name: "new_thing"
         params:
@@ -31,7 +31,7 @@ constructors:
         return:
           type: "equivalent_struct_pointer"
 destructor:
-  wrapped:
+  source:
     c:
       name: "destroy_a_struct"
       params:

--- a/test/fixtures/pointer_class_and_child.yml
+++ b/test/fixtures/pointer_class_and_child.yml
@@ -18,7 +18,7 @@ version: "0.6.0"
 classes:
   - name: "ParentPointer"
     namespace: "wrapture_test"
-    wrapped:
+    source:
       c:
         pointer:
           name: "wrapped_struct"
@@ -27,7 +27,7 @@ classes:
     parent:
       name: "ParentPointer"
       includes: "ParentPointer.hpp"
-    wrapped:
+    source:
       c:
         pointer:
           name: "wrapped_struct"

--- a/test/fixtures/pointer_class_and_child_with_different_struct.yml
+++ b/test/fixtures/pointer_class_and_child_with_different_struct.yml
@@ -19,7 +19,7 @@ classes:
   - name: "ParentPointer"
     namespace: "wrapture_test"
     type: "pointer"
-    wrapped:
+    source:
       c:
         name: "wrapped_struct"
   - name: "ChildPointer"
@@ -28,6 +28,6 @@ classes:
     parent:
       name: "ParentPointer"
       includes: "ParentPointer.hpp"
-    wrapped:
+    source:
       c:
         name: "wrapped_struct_but_different"

--- a/test/fixtures/pointer_class_with_equivalent_pointer_constructor.yml
+++ b/test/fixtures/pointer_class_with_equivalent_pointer_constructor.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2025 Joel E. Anderson
+# Copyright 2025-2026 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,12 +16,12 @@
 
 name: "PointerClassWithExplicitPointerConstructor"
 namespace: "wrapture_test"
-wrapped:
+source:
   c:
     pointer:
       name: "wrapped_struct"
 constructors:
-  - wrapped:
+  - source:
       c:
         name: "new_thing"
         params:
@@ -30,7 +30,7 @@ constructors:
         return:
           type: "equivalent_struct_pointer"
 destructor:
-  wrapped:
+  source:
     c:
       name: "destroy_a_struct"
       params:

--- a/test/fixtures/pointer_class_with_explicit_pointer_constructor.yml
+++ b/test/fixtures/pointer_class_with_explicit_pointer_constructor.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2025 Joel E. Anderson
+# Copyright 2025-2026 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,12 +16,12 @@
 
 name: "PointerClassWithExplicitPointerConstructor"
 namespace: "wrapture_test"
-wrapped:
+source:
   c:
     pointer:
       name: "wrapped_struct"
 constructors:
-  - wrapped:
+  - source:
       c:
         name: "new_thing"
         params:
@@ -30,7 +30,7 @@ constructors:
         return:
           type: "equivalent_struct_pointer"
 destructor:
-  wrapped:
+  source:
     c:
       name: "destroy_a_struct"
       params:

--- a/test/fixtures/scope_with_anchors.yml
+++ b/test/fixtures/scope_with_anchors.yml
@@ -22,56 +22,56 @@ to_string_common: &to_string_common
 classes:
   - name: "OneClass"
     namespace: &dr_seuss_namespace "wrapture_test"
-    wrapped:
+    source:
       c:
         pointer:
           name: "one_struct"
           includes: "one_struct.h"
     functions:
       - <<: *to_string_common
-        wrapped:
+        source:
           c:
             name: "one_struct_to_string"
             params:
               - value: "equivalent_struct_pointer"
   - name: "TwoClass"
     namespace: *dr_seuss_namespace
-    wrapped:
+    source:
       c:
         pointer:
           name: "two_struct"
           includes: "two_struct.h"
     functions:
       - <<: *to_string_common
-        wrapped:
+        source:
           c:
             name: "two_struct_to_string"
             params:
               - value: "equivalent_struct_pointer"
   - name: "RedClass"
     namespace: *dr_seuss_namespace
-    wrapped:
+    source:
       c:
         pointer:
           name: "red_struct"
           includes: "red_struct.h"
     functions:
       - <<: *to_string_common
-        wrapped:
+        source:
           c:
             name: "red_struct_to_string"
             params:
               - value: "equivalent_struct_pointer"
   - name: "BlueClass"
     namespace: *dr_seuss_namespace
-    wrapped:
+    source:
       c:
         pointer:
           name: "blue_struct"
           includes: "blue_struct.h"
     functions:
       - <<: *to_string_common
-        wrapped:
+        source:
           c:
             name: "blue_struct_to_string"
             params:

--- a/test/fixtures/scope_with_enum.yml
+++ b/test/fixtures/scope_with_enum.yml
@@ -25,7 +25,7 @@ classes:
   - name: "BasicClass"
     namespace: "wrapture_test"
     type: "pointer"
-    wrapped:
+    source:
       c:
         name: "basic_struct"
         includes: "basic_struct.h"
@@ -33,7 +33,7 @@ classes:
       - name: "do_stuff"
         return:
           type: "self_reference"
-        wrapped:
+        source:
           c:
             name: "do_stuff_with_basic_struct"
             params:

--- a/test/fixtures/scope_with_exceptions.yml
+++ b/test/fixtures/scope_with_exceptions.yml
@@ -22,7 +22,7 @@ classes:
     namespace: 'wrapture_test'
     functions:
       - name: "IMightFail"
-        wrapped:
+        source:
           c:
             name: "might_fail"
             return:

--- a/test/fixtures/scope_with_pointer_param.yml
+++ b/test/fixtures/scope_with_pointer_param.yml
@@ -17,7 +17,7 @@
 classes:
   - name: "Bullet"
     namespace: "wrapture_test"
-    wrapped:
+    source:
       c:
         pointer:
           name: "bullet_struct"
@@ -25,7 +25,7 @@ classes:
     type: "pointer"
   - name: "Rifle"
     namespace: "wrapture_test"
-    wrapped:
+    source:
       c:
         pointer:
           name: "rifle_struct"
@@ -38,7 +38,7 @@ classes:
             includes: "Bullet.hpp"
         return:
           type: "self_reference"
-        wrapped:
+        source:
           c:
             name: "load_rifle_with_bullet"
             params:
@@ -52,7 +52,7 @@ classes:
             includes: "Bullet.hpp"
         return:
           type: "self_reference"
-        wrapped:
+        source:
           c:
             name: "fire_bullet_from_rifle"
             params:

--- a/test/fixtures/scope_with_reference_param.yml
+++ b/test/fixtures/scope_with_reference_param.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2025 Joel E. Anderson
+# Copyright 2025-2026 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,14 +17,14 @@
 classes:
   - name: "Bullet"
     namespace: "wrapture_test"
-    wrapped:
+    source:
       c:
         name: "bullet_struct"
         includes: "bullet_struct.h"
     type: "pointer"
   - name: "Rifle"
     namespace: "wrapture_test"
-    wrapped:
+    source:
       c:
         name: "rifle_struct"
         includes: "rifle_struct.h"
@@ -35,7 +35,7 @@ classes:
             type: "Bullet&"
         return:
           type: "self-reference"
-        wrapped:
+        source:
           c:
             name: "load_rifle_with_bullet"
             params:

--- a/test/fixtures/self_reference_class.yml
+++ b/test/fixtures/self_reference_class.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2025 Joel E. Anderson
+# Copyright 2025-2026 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 name: "SelfReferenceClass"
 namespace: "wrapture_test"
 includes: "class_include.h"
-wrapped:
+source:
   c:
     name: "basic_struct"
     includes: "folder/include_file_1.h"
@@ -28,7 +28,7 @@ functions:
         type: "const char *"
     return:
       type: "self_reference"
-    wrapped:
+    source:
       c:
         name: "underlying_basic_function"
         params:

--- a/test/fixtures/static_function_class.yml
+++ b/test/fixtures/static_function_class.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2025 Joel E. Anderson
+# Copyright 2025-2026 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 name: "ClassWithStaticFunction"
 namespace: "wrapture_test"
-wrapped:
+source:
   c:
     name: "basic_struct"
 functions:
@@ -25,7 +25,7 @@ functions:
     params:
       - name: "my_param"
         type: "int"
-    wrapped:
+    source:
       c:
         name: "underlying_basic_function"
         params:

--- a/test/fixtures/struct_wrapper_class.yml
+++ b/test/fixtures/struct_wrapper_class.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2025 Joel E. Anderson
+# Copyright 2025-2026 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 name: "StructWrapperClass"
 namespace: "wrapture_test"
-wrapped:
+source:
   c:
     name: "struct_to_wrap"
     includes:
@@ -33,7 +33,7 @@ functions:
   - name: "WrappedFunction"
     return:
       type: "StructWrapperClass"
-    wrapped:
+    source:
       c:
         name: "native_function"
         params:

--- a/test/fixtures/variadic_functions.yml
+++ b/test/fixtures/variadic_functions.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2025 Joel E. Anderson
+# Copyright 2025-2026 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
     - name: "app_name"
       type: "const char *"
     - name: "..."
-  wrapped:
+  source:
     c:
       name: "underlying_function"
       params:
@@ -31,7 +31,7 @@
       type: "const char *"
     - name: "..."
     - name: "..."
-  wrapped:
+  source:
     c:
       name: "underlying_function"
       params:
@@ -42,7 +42,7 @@
     - name: "..."
     - name: "app_name"
       type: "const char *"
-  wrapped:
+  source:
     c:
       name: "underlying_function"
       params:

--- a/test/fixtures/versioned_class.yml
+++ b/test/fixtures/versioned_class.yml
@@ -17,6 +17,6 @@
 name: "MinimalClass"
 version: "0.6.0"
 namespace: "wrapture_test"
-wrapped:
+source:
   c:
     name: "minimal_struct"

--- a/test/fixtures/versioned_function.yml
+++ b/test/fixtures/versioned_function.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2025 Joel E. Anderson
+# Copyright 2025-2026 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ version: "0.2.0"
 params:
   - name: "app_name"
     type: "const char *"
-wrapped:
+source:
   c:
     name: "underlying_basic_function"
     includes:

--- a/test/fixtures/versioned_scope.yml
+++ b/test/fixtures/versioned_scope.yml
@@ -18,11 +18,11 @@ version: "0.6.0"
 classes:
   - name: "MinimalClassOne"
     namespace: "wrapture_test"
-    wrapped:
+    source:
       c:
         name: "minimal_struct_one"
   - name: "MinimalClassTwo"
     namespace: "wrapture_test"
-    wrapped:
+    source:
       c:
         name: "minimal_struct_two"

--- a/test/unit/test_action_spec.rb
+++ b/test/unit/test_action_spec.rb
@@ -2,7 +2,7 @@
 
 # frozen_string_literal: true
 
-# Copyright 2020-2025 Joel E. Anderson
+# Copyright 2020-2026 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,9 +26,9 @@ class ActionSpecTest < Minitest::Test
   def test_basic
     test_spec = fixture_hash('basic_action')
     spec = Wrapture::ActionSpec.new(test_spec)
-    common_includes = spec.includes & test_spec[:wrapped][:c][:includes]
+    common_includes = spec.includes & test_spec[:source][:c][:includes]
 
-    assert_equal(common_includes, test_spec[:wrapped][:c][:includes])
+    assert_equal(common_includes, test_spec[:source][:c][:includes])
   end
 
   def test_exception_without_params

--- a/test/unit/test_class_spec.rb
+++ b/test/unit/test_class_spec.rb
@@ -129,7 +129,7 @@ class ClassSpecTest < Minitest::Test
     assert(source_file_contains_match?(source, destructor_regex),
            'the destructor definition was not found')
 
-    wrapped_function = test_spec[:constructors][0][:wrapped][:c]
+    wrapped_function = test_spec[:constructors][0][:source][:c]
 
     assert(source_file_contains_match?(source, /= #{wrapped_function[:name]}/),
            'source file does not include the wrapped function')

--- a/test/unit/wrapper/test_c.rb
+++ b/test/unit/wrapper/test_c.rb
@@ -2,7 +2,7 @@
 
 # frozen_string_literal: true
 
-# Copyright 2025 Joel E. Anderson
+# Copyright 2025-2026 Joel E. Anderson
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,12 +24,12 @@ require 'wrapture'
 
 class CWrapperTest < Minitest::Test
   def test_class_includes_with_no_c_details
-    # we need a class spec where there isn't a :c key in wrapped
+    # we need a class spec where there isn't a :c key in source
     class_spec = Wrapture::ClassSpec.new(fixture_hash('versioned_class'))
 
     assert_empty(Wrapture::Wrapper::C.includes(class_spec),
                  'includes not empty for a class spec with no ' \
-                 'entry for c in the wrapped languages')
+                 'entry for c in the source languages')
   end
 
   def test_class_with_no_struct_overloads
@@ -55,12 +55,12 @@ class CWrapperTest < Minitest::Test
   end
 
   def test_function_includes_with_no_c_details
-    # we need a function spec where there isn't a :c key in wrapped
+    # we need a function spec where there isn't a :c key in source
     func_spec = Wrapture::FunctionSpec.new(%w[func without c])
 
     assert_empty(Wrapture::Wrapper::C.includes(func_spec),
                  'includes not empty for a func spec with no ' \
-                 'entry for c in the wrapped languages')
+                 'entry for c in the source languages')
   end
 
   def test_overload


### PR DESCRIPTION
The "wrapped" field in hashes and class instances has been renamed to "source" in order to remove the implication of directionality.